### PR TITLE
postgres_output: convert heka message into postgres INSERT

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,20 @@
+image: go1.2
+services:
+  - postgres
+notify:
+  email:
+    recipients:
+    - drone@clever.com
+  hipchat:
+    on_failure: true
+    on_started: true
+    on_success: true
+    room: Clever-Dev-CI
+    token: {{hipchatToken}}
+script:
+  - createdb -h localhost -U postgres drone
+  - psql -U postgres -h localhost -c "CREATE TABLE \"mock_table\" (s text, i int)" drone
+  - cd postgres
+  - go get ./...
+  - go get github.com/stretchr/testify/assert
+  - go test

--- a/README.md
+++ b/README.md
@@ -17,7 +17,24 @@ Testing
 Plugins
 -------
 
-### keen-output.go
+## Decoders
+### Json Decoder
+
+Reads JSON in message payload, and writes its keys and values to the Heka message's fields.
+
+## Encoders
+### Schema Librato Encoder
+### Statmetric Segment Encoder
+
+## Filters
+### InfluxDB Batch Filter
+
+## Outputs
+### Postgres Output
+
+Writes data to a Postgres database.
+
+### Keen Output
+
 Sends event data to Keen.io.
-TODO: Note that we may wish to replace this with the built-in HttpOutput plugin (see https://github.com/mozilla-services/heka/pull/941),
-which unexpectedly made it into Heka's 0.6 release.
+

--- a/postgres/postgres.go
+++ b/postgres/postgres.go
@@ -1,0 +1,95 @@
+package postgres
+
+import (
+	"database/sql"
+	"fmt"
+	_ "github.com/lib/pq"
+	"log"
+)
+
+type PostgresDB struct {
+	*sql.DB
+}
+
+type DBConnectionParams struct {
+	Host           string
+	Port           int
+	DBName         string
+	User           string
+	Password       string
+	SSLMode        string
+	ConnectTimeout int
+}
+
+func New(p *DBConnectionParams) (*PostgresDB, error) {
+	source := fmt.Sprintf("host=%s port=%d dbname=%s connect_timeout=%d sslmode=%s", p.Host, p.Port, p.DBName, p.ConnectTimeout, p.SSLMode)
+	log.Println("Connecting to Postgres:", source)
+	source += fmt.Sprintf(" user=%s password=%s", p.User, p.Password)
+	db, err := sql.Open("postgres", source)
+	if err != nil {
+		return nil, err
+	}
+	return &PostgresDB{DB: db}, nil
+}
+
+// buildInsertQuery returns string of prepared query for inserting one or more values
+func buildInsertQuery(table string, values [][]interface{}) (string, error) {
+	// Validate input
+	if table == "" {
+		return "", fmt.Errorf("table name cannot be empty string")
+	}
+	if len(values) <= 0 {
+		return "", fmt.Errorf("requires at least one value")
+	}
+
+	// Build query
+	q := fmt.Sprintf("INSERT INTO \"%s\" VALUES ", table)
+	fieldCount := -1
+	for valIdx, val := range values {
+		// Validate this value
+		if fieldCount != -1 && len(val) != fieldCount {
+			return "", fmt.Errorf("all values must have the same number of fields. first value had %d fields", fieldCount)
+		}
+		fieldCount = len(val)
+		if fieldCount <= 0 {
+			return "", fmt.Errorf("value must have at least one field")
+		}
+
+		// Add value to the query
+		if valIdx > 0 {
+			q += ", "
+		}
+		q += "("
+		for fieldIdx, _ := range val {
+			if fieldIdx > 0 {
+				q += ", "
+			}
+			q += "$"
+			q += fmt.Sprintf("%d", valIdx*fieldCount+fieldIdx+1)
+		}
+		q += ")"
+	}
+	return q, nil
+}
+
+// Insert one or more values into DB
+func (pi *PostgresDB) Insert(table string, values [][]interface{}) error {
+	q, err := buildInsertQuery(table, values)
+	if err != nil {
+		return err
+	}
+	flatValues := flatten(values)
+	_, err = pi.DB.Query(q, flatValues...)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func flatten(input [][]interface{}) []interface{} {
+	f := []interface{}{}
+	for _, i := range input {
+		f = append(f, i...)
+	}
+	return f
+}

--- a/postgres/postgres_test.go
+++ b/postgres/postgres_test.go
@@ -1,0 +1,94 @@
+package postgres
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func getTestDBConnectionParams() DBConnectionParams {
+	return DBConnectionParams{
+		Host:           "localhost",
+		Port:           5432,
+		DBName:         "drone",
+		User:           "postgres",
+		Password:       "",
+		ConnectTimeout: 5,
+		SSLMode:        "disable",
+	}
+}
+
+func Test_connectToDB(t *testing.T) {
+	p := getTestDBConnectionParams()
+	_, err := New(&p)
+	assert.NoError(t, err)
+}
+
+func Test_buildInsertQuery(t *testing.T) {
+	expected := "INSERT INTO \"mock_table\" VALUES ($1, $2, $3)"
+	actual, err := buildInsertQuery("mock_table", [][]interface{}{
+		{1, 2, 3},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func Test_buildMultiInsertQuery(t *testing.T) {
+	expected := "INSERT INTO \"mock_table\" VALUES ($1, $2, $3), ($4, $5, $6)"
+	actual, err := buildInsertQuery("mock_table", [][]interface{}{
+		{1, 2, 3},
+		{4, 5, 6},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func Test_buildInsertQueryErrorsIfNoTable(t *testing.T) {
+	_, err := buildInsertQuery("", [][]interface{}{
+		{1},
+	})
+	assert.Error(t, err)
+	assert.Equal(t, err.Error(), "table name cannot be empty string")
+}
+
+func Test_buildInsertQueryErrorsIfNoFields(t *testing.T) {
+	_, err := buildInsertQuery("mock_table", [][]interface{}{
+		{}, // 1 value, 0 fields
+	})
+	assert.Error(t, err)
+	assert.Equal(t, err.Error(), "value must have at least one field")
+}
+func Test_buildInsertQueryErrorsIfDifferentNumberOfFields(t *testing.T) {
+	_, err := buildInsertQuery("mock_table", [][]interface{}{
+		{1, 2}, // 2 fields, different number of fields
+		{3},
+	})
+	assert.Error(t, err)
+	assert.Equal(t, err.Error(), "all values must have the same number of fields. first value had 2 fields")
+}
+
+func Test_buildInsertQueryErrorsIfNoValues(t *testing.T) {
+	_, err := buildInsertQuery("mock_table", [][]interface{}{})
+	assert.Error(t, err)
+	assert.Equal(t, err.Error(), "requires at least one value")
+}
+
+func Test_connectAndInsert(t *testing.T) {
+	p := getTestDBConnectionParams()
+	postgresInserter, err := New(&p)
+	assert.NoError(t, err)
+	err = postgresInserter.Insert("mock_table", [][]interface{}{
+		{"foo", 1},
+	})
+	assert.NoError(t, err)
+}
+
+func Test_connectAndBulkInsert(t *testing.T) {
+	p := getTestDBConnectionParams()
+	postgresInserter, err := New(&p)
+	assert.NoError(t, err)
+	err = postgresInserter.Insert("mock_table", [][]interface{}{
+		{"bar", 2},
+		{"baz", 3},
+	})
+	assert.NoError(t, err)
+}

--- a/postgres_output.go
+++ b/postgres_output.go
@@ -1,0 +1,197 @@
+package heka_clever_plugins
+
+import (
+	"fmt"
+	"github.com/clever/heka-clever-plugins/postgres"
+	_ "github.com/lib/pq"
+	"github.com/mozilla-services/heka/message"
+	. "github.com/mozilla-services/heka/pipeline"
+	"strings"
+	"sync"
+	"time"
+)
+
+type PostgresOutput struct {
+	db            *postgres.PostgresDB
+	insertTable   string
+	insertFields  []string
+	batchChan     chan [][]interface{}
+	backChan      chan [][]interface{}
+	flushInterval uint32
+	flushCount    int // Max messages before flush
+}
+
+type PostgresOutputConfig struct {
+	// Table name and fields to write
+	InsertTable  string `toml:"insert_table"`
+	InsertFields string `toml:"insert_fields"`
+
+	// Database Connection
+	DBHost              string `toml:"db_host"`
+	DBPort              int    `toml:"db_port"`
+	DBName              string `toml:"db_name"`
+	DBUser              string `toml:"db_user"`
+	DBPassword          string `toml:"db_password"`
+	DBConnectionTimeout int    `toml:"db_connection_timeout"`
+	DBSSLMode           string `toml:"db_ssl_mode"`
+
+	// Interval at which accumulated messages should be written to Postgres,
+	// in milliseconds (default 1000, i.e. 1 second)
+	FlushInterval uint32 `toml:"flush_interval"`
+	// Number of messages that triggers a write to Postgres (default 10000)
+	FlushCount int `toml:"flush_count"`
+}
+
+func (po *PostgresOutput) ConfigStruct() interface{} {
+	return &PostgresOutputConfig{
+		FlushInterval: uint32(1000),
+		FlushCount:    10000,
+	}
+}
+
+func (po *PostgresOutput) Init(rawConf interface{}) error {
+	config := rawConf.(*PostgresOutputConfig)
+	po.flushInterval = config.FlushInterval
+	po.flushCount = config.FlushCount
+	po.batchChan = make(chan [][]interface{})
+	po.backChan = make(chan [][]interface{}, 2)
+	po.insertTable = config.InsertTable
+	po.insertFields = strings.Split(config.InsertFields, " ")
+	p := postgres.DBConnectionParams{
+		Host:           config.DBHost,
+		Port:           config.DBPort,
+		DBName:         config.DBName,
+		User:           config.DBUser,
+		Password:       config.DBPassword,
+		ConnectTimeout: config.DBConnectionTimeout,
+		SSLMode:        config.DBSSLMode,
+	}
+	pi, err := postgres.New(&p)
+	if err != nil {
+		return err
+	}
+	po.db = pi
+	return nil
+}
+
+func (o *PostgresOutput) Run(or OutputRunner, h PluginHelper) (err error) {
+	defer o.db.Close()
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go o.receiver(or, &wg)
+	go o.committer(or, &wg)
+	wg.Wait()
+	return
+}
+
+// Runs in a separate goroutine, accepting incoming messages, buffering output
+// data until the ticker triggers the buffered data should be put onto the
+// committer channel.
+func (o *PostgresOutput) receiver(or OutputRunner, wg *sync.WaitGroup) {
+	var (
+		pack  *PipelinePack
+		count int
+	)
+	ok := true
+	ticker := time.Tick(time.Duration(o.flushInterval) * time.Millisecond)
+	outBatch := [][]interface{}{}
+	inChan := or.InChan()
+
+	for ok {
+		select {
+		case pack, ok = <-inChan:
+			if !ok {
+				// Closed inChan => we're shutting down, flush data
+				if len(outBatch) > 0 {
+					o.batchChan <- outBatch
+				}
+				close(o.batchChan)
+				break
+			}
+			// Read values from message fields
+			val, e := o.convertMessageToValues(pack.Message, o.insertFields)
+			pack.Recycle()
+			if e != nil {
+				or.LogError(e)
+			} else {
+				outBatch = append(outBatch, val)
+				if count = count + 1; o.CheckFlush(count, len(outBatch)) {
+					if len(outBatch) > 0 {
+						// This will block until the other side is ready to accept
+						// this batch, so we can't get too far ahead.
+						o.batchChan <- outBatch
+						outBatch = <-o.backChan
+						count = 0
+					}
+				}
+			}
+		case <-ticker:
+			if len(outBatch) > 0 {
+				// This will block until the other side is ready to accept
+				// this batch, freeing us to start on the next one.
+				o.batchChan <- outBatch
+				outBatch = <-o.backChan
+				count = 0
+			}
+		}
+	}
+	wg.Done()
+}
+
+// Runs in a separate goroutine, waits for buffered data on the committer
+// channel, bulk inserts it into Postgres, and puts the now empty buffer on the
+// return channel for reuse.
+func (o *PostgresOutput) committer(or OutputRunner, wg *sync.WaitGroup) {
+	initBatch := [][]interface{}{}
+	o.backChan <- initBatch
+	var outBatch [][]interface{}
+
+	for outBatch = range o.batchChan {
+		if err := o.db.Insert(o.insertTable, outBatch); err != nil {
+			or.LogError(err)
+		}
+		outBatch = outBatch[:0]
+		o.backChan <- outBatch
+	}
+	wg.Done()
+}
+
+func (o *PostgresOutput) CheckFlush(count int, length int) bool {
+	if count >= o.flushCount {
+		return true
+	}
+	return false
+}
+
+// convertMessageToValue reads a Heka Message and returns a slice of field values
+func (po *PostgresOutput) convertMessageToValues(m *message.Message, insertFields []string) (fieldValues []interface{}, err error) {
+	fieldValues = []interface{}{}
+	missingFields := []string{}
+	for _, field := range insertFields {
+		// Special case: get "Timestamp" from Heka message
+		if field == "Timestamp" {
+			// Convert Heka time (Unix timestamp in nanoseconds) to Golang time
+			v := time.Unix(0, m.GetTimestamp())
+			fieldValues = append(fieldValues, v)
+		} else {
+			v, ok := m.GetFieldValue(field)
+			if !ok {
+				missingFields = append(missingFields, field)
+				continue
+			}
+			fieldValues = append(fieldValues, v)
+		}
+	}
+
+	if len(missingFields) > 0 {
+		return []interface{}{}, fmt.Errorf("message is missing expected fields:", missingFields)
+	}
+
+	return fieldValues, nil
+}
+
+func init() {
+	RegisterPlugin("PostgresOutput", func() interface{} {
+		return new(PostgresOutput)
+	})
+}


### PR DESCRIPTION
Issue: https://clever.atlassian.net/browse/INFRA-613

This output allows batching Heka messages into a bulk Postgres insert. We read field values from the message, and then write them into the query.

For example, you might receive a message like:
```
:Fields:
    | name:"title" type:string value:"hello"
    | name:"value" type:string value:5
```

You could then configure the table and fields to the write in heka toml: 

```
insert_table=my_table
insert_fields=title value
```

This will result in writing an INSERT like:

```
INSERT INTO "my_table" VALUES ($1, $2)
```

and later parametrizing them with "hello" and 5, i.e.

```
INSERT INTO "my_table" VALUES ("hello", 5)
```

It also supports batching Heka messages to insert multiple, batching on number of messages or ticker duration.