### PR TITLE
postgres_output: allow missing fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ insert_table = "test_table"
 insert_message_fields = "Timestamp field_a field_b"
 insert_table_columns = "col_time col_a col_b"
 
+# If true, will write NULL as a value for any missing field.
+# If false, will error if any of insert_message_fields isn't present on the Heka message.
+allow_missing_message_fields = false # default: true
+
 # Database connection parameters
 db_host = "localhost"
 db_port = 5432
@@ -62,7 +66,7 @@ db_connection_timeout = 5
 
 ### Optional ###
 # Database connection parameters
-db_ssl_mode = "disable" ("require" is default)
+db_ssl_mode = "disable" # default: "require"
 db_connection_timeout = 5
 db_max_open_connections = 1000
 

--- a/postgres_output.go
+++ b/postgres_output.go
@@ -12,21 +12,24 @@ import (
 )
 
 type PostgresOutput struct {
-	db                  *postgres.PostgresDB
-	insertTable         string
-	insertMessageFields []string
-	insertTableColumns  []string
-	batchChan           chan [][]interface{}
-	backChan            chan [][]interface{}
-	flushInterval       uint32
-	flushCount          int // Max messages before flush
+	db                        *postgres.PostgresDB
+	insertTable               string
+	insertMessageFields       []string
+	insertTableColumns        []string
+	batchChan                 chan [][]interface{}
+	backChan                  chan [][]interface{}
+	flushInterval             uint32
+	flushCount                int // Max messages before flush
+	allowMissingMessageFields bool
 }
 
 type PostgresOutputConfig struct {
-	// Table name and fields to write
+	// Table name and colums. Message fields to write.
 	InsertTable         string `toml:"insert_table"`
 	InsertTableColumns  string `toml:"insert_table_columns"`
 	InsertMessageFields string `toml:"insert_message_fields"`
+	// If a field is missing in the Heka message, allow writing NULL
+	AllowMissingMessageFields bool `toml:"allow_missing_message_fields"`
 
 	// Database Connection
 	DBHost               string `toml:"db_host"`
@@ -47,11 +50,12 @@ type PostgresOutputConfig struct {
 
 func (po *PostgresOutput) ConfigStruct() interface{} {
 	return &PostgresOutputConfig{
-		DBConnectionTimeout:  5,
-		DBMaxOpenConnections: 10,
-		DBSSLMode:            "require",
-		FlushInterval:        uint32(1000),
-		FlushCount:           10000,
+		AllowMissingMessageFields: true,
+		DBConnectionTimeout:       5,
+		DBMaxOpenConnections:      10,
+		DBSSLMode:                 "require",
+		FlushInterval:             uint32(1000),
+		FlushCount:                10000,
 	}
 }
 
@@ -70,6 +74,7 @@ func (po *PostgresOutput) Init(rawConf interface{}) error {
 		return fmt.Errorf("config item 'insert_table_columns' cannot be empty string")
 	}
 	po.insertTableColumns = strings.Split(config.InsertTableColumns, " ")
+	po.allowMissingMessageFields = config.AllowMissingMessageFields
 
 	p := postgres.DBConnectionParams{
 		Host:           config.DBHost,
@@ -191,8 +196,13 @@ func (po *PostgresOutput) convertMessageToValues(m *message.Message, insertField
 		} else {
 			v, ok := m.GetFieldValue(field)
 			if !ok {
-				missingFields = append(missingFields, field)
-				continue
+				// If configured to do so, write NULL when a FieldValue isn't found in the Heka message
+				if po.allowMissingMessageFields {
+					v = nil
+				} else {
+					missingFields = append(missingFields, field)
+					continue
+				}
 			}
 			fieldValues = append(fieldValues, v)
 		}

--- a/postgres_output.go
+++ b/postgres_output.go
@@ -209,7 +209,7 @@ func (po *PostgresOutput) convertMessageToValues(m *message.Message, insertField
 	}
 
 	if len(missingFields) > 0 {
-		return []interface{}{}, fmt.Errorf("message is missing expected fields:", missingFields)
+		return []interface{}{}, fmt.Errorf("message is missing expected fields: %s", strings.Join(missingFields, ", "))
 	}
 
 	return fieldValues, nil


### PR DESCRIPTION
Previously, if the Heka message was missing a field, the insert
would always fail with an error.

Now, it's possible to do an insert with missing message fields, where a
NULL value will be written instead.