### PR TITLE
enforce a maximum payload size for json decoder

### DIFF
--- a/lua/decoders/json_decoder.lua
+++ b/lua/decoders/json_decoder.lua
@@ -45,6 +45,12 @@ end
 
 function process_message()
     local payload = read_message("Payload")
+
+    -- check length (cjson.encode will crash if payload is > 11500 characters)
+    if #payload > 11500 then
+       return -1
+    end
+
     local ok, json = pcall(cjson.decode, payload)
     local prefix = ''
     local postfix = ''


### PR DESCRIPTION
- through trial and error, I figured out the max string buffer size is a
  little over 11500 characters, so just throw things larger than that
  away instead of crashing heka