### PR TITLE
Fortify postgres_output

### DIFF
--- a/postgres_output.go
+++ b/postgres_output.go
@@ -14,12 +14,10 @@ import (
 )
 
 type PostgresOutput struct {
-	db *postgres.PostgresDB
-
-	helper           PluginHelper
-	runner           OutputRunner
-	lastMsgLoopCount uint
-
+	db                        *postgres.PostgresDB
+	helper                    PluginHelper
+	runner                    OutputRunner
+	lastMsgLoopCount          uint
 	insertSchema              string
 	insertTable               string
 	insertMessageFields       []string


### PR DESCRIPTION
**Why**: Around 2 week ago I released a new business metric script that would counted the number of authorized apps, teachers, and students for each district.  The script would printed all of its results (8k log lines) in less than a second.  As a result, the Postgres (and Influx) Heka outputs would quickly start reporting idle packets, which halted all Heka processing.

**What**: After much debugging, the root cause turned out to be two fold.  The first issue was that the postgres_output only maintained one batch at a time, which effectively meant that the output blocked on inserts.  The second issue was that occasionally postgres_output sent RedShift insert statements that would take more than 120 seconds to complete, which because of the first issue caused the output to block for over 120 seconds.  Heka marks a pack as idle if it hasn't been recycled within a 120 seconds.  The fix was to make postgres_output not block on inserts by allowing multiple batches to be maintained.

**Testing**: Left a script producing 4k msg/sec running for several hours on Heka staging.  New postgres_output took it like a champ.  The older version tapped out after a couple of minutes.

https://clever.atlassian.net/browse/INFRA-815