### PR TITLE
Add an interpolation filter.

### DIFF
--- a/lua/filters/fieldfix.lua
+++ b/lua/filters/fieldfix.lua
@@ -37,6 +37,20 @@ Config:
     Space delimited string of Fields to rename.  Old and new name should be
     delimited with a '='.
 
+- fields_interpolate (string, optional)
+    Space delimited string of Fields to add, and perform string-interpolation
+    on - i.e. replace chunks of the form %{foo} with the value of the field foo.
+    The new field name and custom values should be delimited with a '='.
+    For example, if fields[foo] is 'hello' and fields[bar] is 'world', then the
+    interpolation msg=%{foo}_%{bar} will result in fields[msg] as 'hello_world'.
+    Note that the interpolation will only be done with the original field
+    values, and not any that have been configured to get renamed or inserted.
+
+
+  Note: that it's possibly to make any Field value in the above configuration a
+  compound value by wrapping it in double quotes, i.e.
+  fields_override = 'msg="hello world" cluster=wibble'
+
 *Example Heka Configuration*
 
 .. code-block:: ini
@@ -55,12 +69,13 @@ Config:
 
 require "string"
 
-local msg_type     = read_config("msg_type") or "fieldfix"
-local payload_keep = read_config("payload_keep")
-local add_str      = read_config("fields_if_missing") or ""
-local override_str = read_config("fields_override") or ""
-local remove_str   = read_config("fields_remove") or ""
-local rename_str   = read_config("fields_rename") or ""
+local msg_type        = read_config("msg_type") or "fieldfix"
+local payload_keep    = read_config("payload_keep")
+local add_str         = read_config("fields_if_missing") or ""
+local override_str    = read_config("fields_override") or ""
+local remove_str      = read_config("fields_remove") or ""
+local rename_str      = read_config("fields_rename") or ""
+local interpolate_str = read_config("fields_interpolate") or ""
 
 -- convert a space-delimited string into a table of kv's,
 -- either splitting each token on '=', or setting the value
@@ -68,8 +83,18 @@ local rename_str   = read_config("fields_rename") or ""
 local function create_table(str)
   local t = {}
   if str:len() > 0 then
-    for f in str:gmatch("[%S]+") do
-      local k, v = f:match("([%S]+)=([%S]+)")
+    local fields = {}
+    -- Expressions with quoted strings
+    for f in str:gmatch("[%S]+=\"[^\"]+\"") do
+      fields[#fields+1] = f
+    end
+    -- Expressions without quoted strings
+    for f in str:gmatch("[%S]+=[^\"][%S]*") do
+      fields[#fields+1] = f
+    end
+    for i=1,#fields do
+      -- Also need to remove the quotes from the final value
+      local k, v = fields[i]:match("([%S]+)=\"?([^\"]+)\"?")
       if k ~= nil then
         t[k] = v
       else
@@ -81,13 +106,22 @@ local function create_table(str)
 end
 
 -- build tables
-local add      = create_table(add_str)
-local remove   = create_table(remove_str)
-local override = create_table(override_str)
-local rename   = create_table(rename_str)
+local add         = create_table(add_str)
+local remove      = create_table(remove_str)
+local override    = create_table(override_str)
+local rename      = create_table(rename_str)
+local interpolate = create_table(interpolate_str)
+
+-- Used for interpolating message fields into series name.
+local function interpolate_func(key)
+    local val = read_message("Fields["..key.."]")
+    if val then
+        return val
+    end
+    return "%{"..key.."}"
+end
 
 function process_message ()
-
     local message = {
       Timestamp  = read_message("Timestamp"),
       Type       = msg_type,
@@ -121,6 +155,14 @@ function process_message ()
     -- Fields to override
     for k,v in pairs(override) do
       message.Fields[k] = v
+    end
+
+    -- Fields to interpolate
+    for k,v in pairs(interpolate) do
+        if string.find(v, "%%{[%w%p]-}") then
+            interpolated = string.gsub(v, "%%{([%w%p]-)}", interpolate_func)
+        end
+        message.Fields[k] = interpolated
     end
 
     inject_message(message)


### PR DESCRIPTION
As discussed in person.
With the following config:
```
[FieldFixFilter]
message_matcher = "Type == 'Kayvee'"
type = "SandboxFilter"
filename = "/heka/clever/filters/fieldfix.lua"
preserve_data = false
    [FieldFixFilter.config]
    fields_if_missing = "source=myhost target=remotehost"
    fields_override = 'cluster="wibble" '
    fields_remove = "product"
    fields_interpolate = 'foobar="my_level: %{level}" hello=world'

[console_output]
type = "LogOutput"
message_matcher = "Type == 'heka.sandbox.fieldfix'"
encoder = "RstEncoder"
```
And the log line:
```
http://lua-users.org/wiki/RangeIterator
```

It produces:
```
:Timestamp: 2015-06-17 23:24:06.599616 +0000 UTC
:Type: heka.sandbox.fieldfix
:Hostname: 2c1932df705c
:Pid: 0
:Uuid: 4998fdc4-fa51-4f21-a918-9c4be44de5d2
:Logger: FieldFixFilter
:Payload: 
:EnvVersion: 
:Severity: 7
:Fields:
    | name:"_prefix" type:string value:""
    | name:"foobar" type:string value:"my_level: notice"
    | name:"source" type:string value:"myhost"
    | name:"_postfix" type:string value:""
    | name:"target" type:string value:"remotehost"
    | name:"level" type:string value:"notice"
    | name:"cluster" type:string value:"wibble"
    | name:"msg" type:string value:"hello, world"
```
