### PR TITLE
Fieldfix allow writing payload

### DIFF
--- a/lua/filters/fieldfix.lua
+++ b/lua/filters/fieldfix.lua
@@ -114,15 +114,6 @@ local remove      = create_table(remove_str)
 local override    = create_table(override_str)
 local rename      = create_table(rename_str)
 
--- For a given value
-local function interpolate_field_values(v)
-    local out = v
-    if string.find(v, "%%{[%w%p]-}") then
-        out = string.gsub(v, "%%{([%w%p]-)}", interpolate_func)
-    end
-    return out
-end
-
 -- Used for interpolating message fields into series name.
 local function interpolate_func(key)
     local val = read_message("Fields["..key.."]")
@@ -130,6 +121,15 @@ local function interpolate_func(key)
         return val
     end
     return "%{"..key.."}"
+end
+
+-- For a given value
+local function interpolate_field_values(v)
+    local out = tostring(v)
+    if string.find(out, "%%{[%w%p]-}") then
+        out = string.gsub(out, "%%{([%w%p]-)}", interpolate_func)
+    end
+    return out
 end
 
 function process_message ()

--- a/lua/filters/fieldfix.lua
+++ b/lua/filters/fieldfix.lua
@@ -20,6 +20,10 @@ Config:
 - payload_keep (bool, default false)
     If true, maintain the original Payloads in the new messages.
 
+- payload (string, optional)
+    If payload_keep is false, this allows overrides the Payload's value.
+    Support string-interpolation (see "fields_override", below).
+
 - fields_if_missing (string, optional)
     Space delimited string of Fields to supplement (ie; add if they're not
     already present).  Field name and value should be delimited with a '='.
@@ -29,6 +33,15 @@ Config:
     existing values if necessary.  Field name and value should be delimited
     with a '='.
 
+    Supports string-interpolation, i.e. replace chunks of the form %{foo} with
+    the value of the field foo.
+
+    For example, if fields[foo] is 'hello' and fields[bar] is 'world', then the
+    interpolation msg=%{foo}_%{bar} will result in fields[msg] as 'hello_world'.
+    Note that the interpolation will only be done with the original field
+    values, and not any that have been configured to get renamed or inserted.
+
+
 - fields_remove (string, optional)
     Space delimited string of Fields to remove.  Only the field name is
     required.
@@ -36,16 +49,6 @@ Config:
 - fields_rename (string, optional)
     Space delimited string of Fields to rename.  Old and new name should be
     delimited with a '='.
-
-- fields_interpolate (string, optional)
-    Space delimited string of Fields to add, and perform string-interpolation
-    on - i.e. replace chunks of the form %{foo} with the value of the field foo.
-    The new field name and custom values should be delimited with a '='.
-    For example, if fields[foo] is 'hello' and fields[bar] is 'world', then the
-    interpolation msg=%{foo}_%{bar} will result in fields[msg] as 'hello_world'.
-    Note that the interpolation will only be done with the original field
-    values, and not any that have been configured to get renamed or inserted.
-
 
   Note: that it's possibly to make any Field value in the above configuration a
   compound value by wrapping it in double quotes, i.e.
@@ -70,12 +73,12 @@ Config:
 require "string"
 
 local msg_type        = read_config("msg_type") or "fieldfix"
-local payload_keep    = read_config("payload_keep")
+local payload_keep    = read_config("payload_keep") or false
+local payload         = read_config("payload")
 local add_str         = read_config("fields_if_missing") or ""
 local override_str    = read_config("fields_override") or ""
 local remove_str      = read_config("fields_remove") or ""
 local rename_str      = read_config("fields_rename") or ""
-local interpolate_str = read_config("fields_interpolate") or ""
 
 -- convert a space-delimited string into a table of kv's,
 -- either splitting each token on '=', or setting the value
@@ -110,7 +113,15 @@ local add         = create_table(add_str)
 local remove      = create_table(remove_str)
 local override    = create_table(override_str)
 local rename      = create_table(rename_str)
-local interpolate = create_table(interpolate_str)
+
+-- For a given value
+local function interpolate_field_values(v)
+    local out = v
+    if string.find(v, "%%{[%w%p]-}") then
+        out = string.gsub(v, "%%{([%w%p]-)}", interpolate_func)
+    end
+    return out
+end
 
 -- Used for interpolating message fields into series name.
 local function interpolate_func(key)
@@ -128,7 +139,14 @@ function process_message ()
       EnvVersion = read_message("EnvVersion"),
       Fields     = {}
     }
-    if payload_keep then message.Payload = read_message("Payload") end
+
+    if payload_keep then
+        -- Use existing payload
+        message.Payload = read_message("Payload")
+    else
+        -- Override existing payload
+        if payload then message.Payload = interpolate_field_values(payload) end
+    end
 
     while true do
         local typ, name, value, representation, count = read_next_field()
@@ -154,15 +172,7 @@ function process_message ()
 
     -- Fields to override
     for k,v in pairs(override) do
-      message.Fields[k] = v
-    end
-
-    -- Fields to interpolate
-    for k,v in pairs(interpolate) do
-        if string.find(v, "%%{[%w%p]-}") then
-            interpolated = string.gsub(v, "%%{([%w%p]-)}", interpolate_func)
-        end
-        message.Fields[k] = interpolated
+       message.Fields[k] = interpolate_field_values(v)
     end
 
     inject_message(message)


### PR DESCRIPTION
- added `payload` to the config, to allow rewriting its value. (It can't be rewritten like other fields)
- combined `fields_override` and `fields_interpolate`, since they are have same behavior just one interpolates. now only `fields_override` exists, and interpolate is just a feature

