### PR TITLE
IP-263: Longer timeout for queries  + extra check against int16 overflow

### DIFF
--- a/all_plugins_test.go
+++ b/all_plugins_test.go
@@ -13,7 +13,6 @@ func TestAllSpecs(t *testing.T) {
 
 	r.AddSpec(KeenOutputSpec)
 	r.AddSpec(JsonDecoderSpec)
-	r.AddSpec(FieldEncoderSpec)
 
 	gs.MainGoTest(r, t)
 }

--- a/postgres/postgres.go
+++ b/postgres/postgres.go
@@ -77,7 +77,7 @@ func buildInsertQuery(schema, table string, columns []string, values [][]interfa
 				q += ", "
 			}
 			q += "$"
-			q += fmt.Sprintf("%d", valIdx*columnCount+fieldIdx+1)
+			q += fmt.Sprintf("%d", uint64(valIdx)*uint64(columnCount)+uint64(fieldIdx)+1)
 		}
 		q += ")"
 	}

--- a/postgres_output.go
+++ b/postgres_output.go
@@ -52,7 +52,7 @@ type PostgresOutputConfig struct {
 	// Number of messages that triggers a write to Postgres (default 10000)
 	FlushCount int `toml:"flush_count"`
 	// The time in milliseconds that the plugin will wait before giving up
-	// on a Postgres query (defaults to 60000, i.e. 1 minute)
+	// on a Postgres query (defaults to 300000, i.e. 5 minute)
 	QueryTimeout uint32 `toml:"query_timeout"`
 }
 
@@ -65,7 +65,7 @@ func (po *PostgresOutput) ConfigStruct() interface{} {
 		FlushInterval:             uint32(1000),
 		FlushCount:                10000,
 		InsertSchema:              "public",
-		QueryTimeout:              uint32(60000),
+		QueryTimeout:              uint32(300000),
 	}
 }
 


### PR DESCRIPTION
We were seeing errors of the form: `pq: there is no parameter $-32768` and `Postgres insert took more than 60000ms.`. This PR (tested in staging) increases the timeout for the queries and adds extra checks on the line that seemed to be the culprit for the `pq: there is no parameter $-32768` error.