### PR TITLE
INFRA-1175: allow setting timestamp column name through config

### DIFF
--- a/firehose_output.go
+++ b/firehose_output.go
@@ -2,6 +2,7 @@ package heka_clever_plugins
 
 import (
 	"encoding/json"
+	"time"
 
 	"github.com/Clever/heka-clever-plugins/aws"
 
@@ -9,12 +10,14 @@ import (
 )
 
 type FirehoseOutput struct {
-	client aws.RecordPutter
+	client          aws.RecordPutter
+	timestampColumn string
 }
 
 type FirehoseOutputConfig struct {
-	Stream string `toml:"stream"`
-	Region string `toml:"region"`
+	Stream          string `toml:"stream"`
+	Region          string `toml:"region"`
+	TimestampColumn string `toml:"timestamp_column"`
 }
 
 func (f *FirehoseOutput) ConfigStruct() interface{} {
@@ -24,12 +27,14 @@ func (f *FirehoseOutput) ConfigStruct() interface{} {
 func (f *FirehoseOutput) Init(rawConfig interface{}) error {
 	config := rawConfig.(*FirehoseOutputConfig)
 	f.client = aws.NewFirehose(config.Region, config.Stream)
+	f.timestampColumn = config.TimestampColumn
 	return nil
 }
 
 func (f *FirehoseOutput) Run(or pipeline.OutputRunner, h pipeline.PluginHelper) error {
 	for pack := range or.InChan() {
 		payload := pack.Message.GetPayload()
+		timestamp := time.Unix(0, pack.Message.GetTimestamp()).Format("2006-01-02 15:04:05.000")
 		pack.Recycle(nil)
 
 		// Verify input is valid json
@@ -40,8 +45,19 @@ func (f *FirehoseOutput) Run(or pipeline.OutputRunner, h pipeline.PluginHelper) 
 			continue
 		}
 
+		if f.timestampColumn != "" {
+			// add timestamp to column named in timestampColumn
+			object[f.timestampColumn] = timestamp
+		}
+
+		record, err := json.Marshal(object)
+		if err != nil {
+			or.LogError(err)
+			continue
+		}
+
 		// Send data to the firehose
-		err = f.client.PutRecord([]byte(payload))
+		err = f.client.PutRecord(record)
 		if err != nil {
 			or.LogError(err)
 			continue

--- a/firehose_output.go
+++ b/firehose_output.go
@@ -46,7 +46,7 @@ func (f *FirehoseOutput) Run(or pipeline.OutputRunner, h pipeline.PluginHelper) 
 		}
 
 		if f.timestampColumn != "" {
-			// add timestamp to column named in timestampColumn
+			// add Heka message's timestamp to column named in timestampColumn
 			object[f.timestampColumn] = timestamp
 		}
 

--- a/firehose_output_test.go
+++ b/firehose_output_test.go
@@ -2,6 +2,7 @@ package heka_clever_plugins
 
 import (
 	"testing"
+	"time"
 
 	"github.com/mozilla-services/heka/message"
 	"github.com/mozilla-services/heka/pipeline"
@@ -39,6 +40,46 @@ func TestRun(t *testing.T) {
 	}()
 
 	mockFirehose.EXPECT().PutRecord([]byte(input)).Return(nil)
+
+	err := firehoseOutput.Run(mockOR, mockPH)
+	assert.NoError(t, err, "did not expect err for valid Run()")
+}
+
+// TestRunWithTimestamp tests that if a TimestampColumn is provided in the config
+// then the Heka message's timestamp gets added to the message with that column name.
+func TestRunWithTimestamp(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockOR := pipelinemock.NewMockOutputRunner(mockCtrl)
+	mockPH := pipelinemock.NewMockPluginHelper(mockCtrl)
+	mockFirehose := NewMockRecordPutter(mockCtrl)
+
+	firehoseOutput := FirehoseOutput{
+		client:          mockFirehose,
+		timestampColumn: "created",
+	}
+
+	testChan := make(chan *pipeline.PipelinePack)
+	mockOR.EXPECT().InChan().Return(testChan)
+
+	// Send test input through the channel
+	input := `{}`
+	timestamp := time.Date(2015, 07, 1, 13, 14, 15, 0, time.UTC).UnixNano()
+	go func() {
+		testPack := pipeline.PipelinePack{
+			Message: &message.Message{
+				Payload:   &input,
+				Timestamp: &timestamp,
+			},
+		}
+
+		testChan <- &testPack
+		close(testChan)
+	}()
+
+	expected := `{"created":"2015-07-01 13:14:15.000"}`
+	mockFirehose.EXPECT().PutRecord([]byte(expected)).Return(nil)
 
 	err := firehoseOutput.Run(mockOR, mockPH)
 	assert.NoError(t, err, "did not expect err for valid Run()")


### PR DESCRIPTION
Quite a few of the event tables have timestamp in them, but the name of the timestamp column is not always the same. This allows the firehose config to specify a name for the timestamp column in Redshift.