### PR TITLE
firehose: use encoder if payload is not json

### DIFF
--- a/firehose_output_test.go
+++ b/firehose_output_test.go
@@ -3,6 +3,7 @@ package heka_clever_plugins
 import (
 	"testing"
 	"time"
+	"errors"
 
 	"github.com/mozilla-services/heka/message"
 	"github.com/mozilla-services/heka/pipeline"
@@ -64,6 +65,46 @@ func TestRunWithTimestamp(t *testing.T) {
 	mockOR.EXPECT().InChan().Return(testChan)
 
 	// Send test input through the channel
+	input := `{"key": "value"}`
+	timestamp := time.Date(2015, 07, 1, 13, 14, 15, 0, time.UTC).UnixNano()
+	go func() {
+		testPack := pipeline.PipelinePack{
+			Message: &message.Message{
+				Payload:   &input,
+				Timestamp: &timestamp,
+			},
+		}
+
+		testChan <- &testPack
+		close(testChan)
+	}()
+
+	expected := `{"created":"2015-07-01 13:14:15.000","key":"value"}`
+	mockFirehose.EXPECT().PutRecord([]byte(expected)).Return(nil)
+
+	err := firehoseOutput.Run(mockOR, mockPH)
+	assert.NoError(t, err, "did not expect err for valid Run()")
+}
+
+// TestRunWithoutData tests that if an empty row is passed to the plugin
+// then the plugin returns an error but continues
+func TestRunWithoutData(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockOR := pipelinemock.NewMockOutputRunner(mockCtrl)
+	mockPH := pipelinemock.NewMockPluginHelper(mockCtrl)
+	mockFirehose := NewMockRecordPutter(mockCtrl)
+
+	firehoseOutput := FirehoseOutput{
+		client:          mockFirehose,
+		timestampColumn: "created",
+	}
+
+	testChan := make(chan *pipeline.PipelinePack)
+	mockOR.EXPECT().InChan().Return(testChan)
+
+	// Send test input through the channel
 	input := `{}`
 	timestamp := time.Date(2015, 07, 1, 13, 14, 15, 0, time.UTC).UnixNano()
 	go func() {
@@ -78,9 +119,9 @@ func TestRunWithTimestamp(t *testing.T) {
 		close(testChan)
 	}()
 
-	expected := `{"created":"2015-07-01 13:14:15.000"}`
-	mockFirehose.EXPECT().PutRecord([]byte(expected)).Return(nil)
+	expected_error := errors.New("No fields found in message")
+	mockOR.EXPECT().LogError(expected_error).Return()
 
 	err := firehoseOutput.Run(mockOR, mockPH)
-	assert.NoError(t, err, "did not expect err for valid Run()")
+	assert.NoError(t, err, "don't fail Run() for no fields found")
 }


### PR DESCRIPTION
* we should always be using an encoder but backwards compatibility
* rather than the current way we should fall back to payload
* added check to not write anything to s3 if it's an empty object