### PR TITLE
INFRA-1438 Add batching support to firehose output

### DIFF
--- a/firehose_output.go
+++ b/firehose_output.go
@@ -3,6 +3,9 @@ package heka_clever_plugins
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Clever/heka-clever-plugins/aws"
@@ -11,25 +14,72 @@ import (
 	"github.com/mozilla-services/heka/pipeline"
 )
 
+type MsgPack struct {
+	record      []byte
+	queueCursor string
+}
+
 type FirehoseOutput struct {
-	client          aws.RecordPutter
-	timestampColumn string
+	recvRecordCount    int64
+	sentRecordCount    int64
+	droppedRecordCount int64
+	batchedRecords     [][]byte
+	queueCursor        string
+	batchChan          chan MsgPack
+	stopChan           chan bool
+	client             aws.RecordPutter
+	conf               *FirehoseOutputConfig
+	or                 pipeline.OutputRunner
+	reportLock         sync.Mutex
+	flushTicker        *time.Ticker
 }
 
 type FirehoseOutputConfig struct {
-	Stream          string `toml:"stream"`
-	Region          string `toml:"region"`
+	// Kineses stream name to put data to
+	Stream string `toml:"stream"`
+	// AWS region the stream lives in
+	Region string `toml:"region"`
+	// Optional column to use as the message timestamp
 	TimestampColumn string `toml:"timestamp_column"`
+	// Interval at which accumulated messages should be bulk put to
+	// firehose, in milliseconds (default 1000, i.e. 1 second).
+	FlushInterval uint32 `toml:"flush_interval"`
+	// Number of messages that triggers a put to firehose
+	// (default to 1)
+	FlushCount int `toml:"flush_count"`
 }
 
 func (f *FirehoseOutput) ConfigStruct() interface{} {
-	return &FirehoseOutputConfig{}
+	return &FirehoseOutputConfig{
+		FlushInterval: 1000,
+		FlushCount:    1,
+	}
 }
 
-func (f *FirehoseOutput) Init(rawConfig interface{}) error {
-	config := rawConfig.(*FirehoseOutputConfig)
-	f.client = aws.NewFirehose(config.Region, config.Stream)
-	f.timestampColumn = config.TimestampColumn
+func (f *FirehoseOutput) Init(config interface{}) error {
+	f.conf = config.(*FirehoseOutputConfig)
+
+	f.batchChan = make(chan MsgPack, 100)
+	f.batchedRecords = make([][]byte, 0, f.conf.FlushCount)
+
+	f.client = aws.NewFirehose(f.conf.Region, f.conf.Stream)
+	return nil
+}
+
+func (f *FirehoseOutput) Prepare(or pipeline.OutputRunner, h pipeline.PluginHelper) error {
+	f.or = or
+	f.stopChan = or.StopChan()
+
+	// Setup the batch ticker
+	if f.conf.FlushInterval > 0 {
+		d, err := time.ParseDuration(fmt.Sprintf("%dms", f.conf.FlushInterval))
+		if err != nil {
+			return fmt.Errorf("can't create flush ticker: %s", err.Error())
+		}
+		f.flushTicker = time.NewTicker(d)
+	}
+
+	go f.batchSender()
 	return nil
 }
 
@@ -58,47 +108,116 @@ func (f *FirehoseOutput) parseFields(pack *pipeline.PipelinePack) map[string]int
 	return object
 }
 
-func (f *FirehoseOutput) Run(or pipeline.OutputRunner, h pipeline.PluginHelper) error {
-	for pack := range or.InChan() {
-		payload := pack.Message.GetPayload()
-		timestamp := time.Unix(0, pack.Message.GetTimestamp()).Format("2006-01-02 15:04:05.000")
+func (f *FirehoseOutput) ProcessMessage(pack *pipeline.PipelinePack) error {
+	atomic.AddInt64(&f.recvRecordCount, 1)
+	payload := pack.Message.GetPayload()
+	timestamp := time.Unix(0, pack.Message.GetTimestamp()).Format("2006-01-02 15:04:05.000")
 
-		// Verify input is valid json
-		object := make(map[string]interface{})
-		err := json.Unmarshal([]byte(payload), &object)
-		if err != nil {
-			// Since payload is not a json object, parse the entire pack
-			// into a map of fields and dynamic fields
-			object = f.parseFields(pack)
-		}
-
-		// Only recycle the pack after all data has been pulled from it
-		pack.Recycle(nil)
-
-		if len(object) == 0 {
-			or.LogError(errors.New("No fields found in message"))
-			continue
-		}
-
-		if f.timestampColumn != "" {
-			// add Heka message's timestamp to column named in timestampColumn
-			object[f.timestampColumn] = timestamp
-		}
-
-		record, err := json.Marshal(object)
-		if err != nil {
-			or.LogError(err)
-			continue
-		}
-
-		// Send data to the firehose
-		err = f.client.PutRecord(record)
-		if err != nil {
-			or.LogError(err)
-			continue
-		}
+	// Verify input is valid json
+	object := make(map[string]interface{})
+	err := json.Unmarshal([]byte(payload), &object)
+	if err != nil {
+		// Since payload is not a json object, parse the entire pack
+		// into a map of fields and dynamic fields
+		object = f.parseFields(pack)
 	}
 
+	if len(object) == 0 {
+		atomic.AddInt64(&f.droppedRecordCount, 1)
+		return errors.New("No fields found in message")
+	}
+
+	if f.conf.TimestampColumn != "" {
+		// add Heka message's timestamp to column named in timestampColumn
+		object[f.conf.TimestampColumn] = timestamp
+	}
+
+	record, err := json.Marshal(object)
+	if err != nil {
+		atomic.AddInt64(&f.droppedRecordCount, 1)
+		return err
+	}
+
+	// Send data to the firehose
+	if f.conf.FlushCount == 1 {
+		err = f.client.PutRecord(record)
+		if err != nil {
+			atomic.AddInt64(&f.droppedRecordCount, 1)
+			return err
+		} else {
+			f.or.UpdateCursor(pack.QueueCursor)
+			atomic.AddInt64(&f.sentRecordCount, 1)
+		}
+	} else {
+		// Batch the data
+		f.batchChan <- MsgPack{record: record, queueCursor: pack.QueueCursor}
+	}
+
+	return nil
+}
+
+// batchSender is a go routine that gets sent:
+//   - messages to be batched
+//   - a stop signal
+//   - a flush signal
+func (f *FirehoseOutput) batchSender() {
+	ok := true
+	for ok {
+		select {
+		case <-f.stopChan:
+			ok = false
+			continue
+		case pack := <-f.batchChan:
+			f.batchedRecords = append(f.batchedRecords, pack.record)
+			f.queueCursor = pack.queueCursor
+			if len(f.batchedRecords) >= f.conf.FlushCount {
+				f.sendBatch()
+			}
+		case <-f.flushTicker.C:
+			if len(f.batchedRecords) > 0 {
+				f.sendBatch()
+			}
+		}
+	}
+}
+
+// sendBatch is called everytime the batchedRecords queue is full or
+// the timer has expired
+func (f *FirehoseOutput) sendBatch() {
+	count := int64(len(f.batchedRecords))
+	err := f.client.PutRecordBatch(f.batchedRecords)
+
+	// Update the cursor (these messages are either lost forever or sent)
+	// and reset the queue
+	f.or.UpdateCursor(f.queueCursor)
+	f.batchedRecords = f.batchedRecords[0:0]
+
+	if err != nil {
+		// TODO: PutRecordBatch should return the number of successful records
+		//       so that the correct amount can be set here
+		atomic.AddInt64(&f.droppedRecordCount, count)
+		f.or.LogError(err)
+	} else {
+		atomic.AddInt64(&f.sentRecordCount, count)
+	}
+}
+
+func (f *FirehoseOutput) CleanUp() {
+	if f.flushTicker != nil {
+		f.flushTicker.Stop()
+	}
+}
+
+func (f *FirehoseOutput) ReportMsg(msg *message.Message) error {
+	f.reportLock.Lock()
+	defer f.reportLock.Unlock()
+
+	message.NewInt64Field(msg, "sentRecordCount",
+		atomic.LoadInt64(&f.sentRecordCount), "count")
+	message.NewInt64Field(msg, "droppedRecordCount",
+		atomic.LoadInt64(&f.droppedRecordCount), "count")
+	message.NewInt64Field(msg, "recvRecordCount",
+		atomic.LoadInt64(&f.recvRecordCount), "count")
 	return nil
 }
 

--- a/firehose_output_test.go
+++ b/firehose_output_test.go
@@ -1,9 +1,9 @@
 package heka_clever_plugins
 
 import (
+	"runtime"
 	"testing"
 	"time"
-	"errors"
 
 	"github.com/mozilla-services/heka/message"
 	"github.com/mozilla-services/heka/pipeline"
@@ -12,116 +12,180 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRun(t *testing.T) {
+// TestJSONMessage tests that Messages with JSON Payloads get sent
+func TestJSONMessage(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
 	mockOR := pipelinemock.NewMockOutputRunner(mockCtrl)
-	mockPH := pipelinemock.NewMockPluginHelper(mockCtrl)
 	mockFirehose := NewMockRecordPutter(mockCtrl)
-
+	conf := FirehoseOutputConfig{
+		FlushCount:    1,
+		FlushInterval: 0,
+	}
 	firehoseOutput := FirehoseOutput{
 		client: mockFirehose,
+		conf:   &conf,
+		or:     mockOR,
 	}
-
-	testChan := make(chan *pipeline.PipelinePack)
-	mockOR.EXPECT().InChan().Return(testChan)
 
 	// Send test input through the channel
 	input := `{"key":"value"}`
-	go func() {
-		testPack := pipeline.PipelinePack{
-			Message: &message.Message{
-				Payload: &input,
-			},
-		}
-
-		testChan <- &testPack
-		close(testChan)
-	}()
+	testPack := pipeline.PipelinePack{
+		Message: &message.Message{
+			Payload: &input,
+		},
+		QueueCursor: "queuecursor",
+	}
 
 	mockFirehose.EXPECT().PutRecord([]byte(input)).Return(nil)
-
-	err := firehoseOutput.Run(mockOR, mockPH)
-	assert.NoError(t, err, "did not expect err for valid Run()")
+	mockOR.EXPECT().UpdateCursor("queuecursor")
+	err := firehoseOutput.ProcessMessage(&testPack)
+	assert.NoError(t, err, "did not expect err for valid message")
 }
 
-// TestRunWithTimestamp tests that if a TimestampColumn is provided in the config
-// then the Heka message's timestamp gets added to the message with that column name.
-func TestRunWithTimestamp(t *testing.T) {
+// TestEmptyMessage tests that an error is generated when there is an empty
+// JSON message
+func TestEmptyMessage(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
 	mockOR := pipelinemock.NewMockOutputRunner(mockCtrl)
-	mockPH := pipelinemock.NewMockPluginHelper(mockCtrl)
 	mockFirehose := NewMockRecordPutter(mockCtrl)
-
-	firehoseOutput := FirehoseOutput{
-		client:          mockFirehose,
-		timestampColumn: "created",
+	conf := FirehoseOutputConfig{
+		FlushCount:    1,
+		FlushInterval: 0,
 	}
-
-	testChan := make(chan *pipeline.PipelinePack)
-	mockOR.EXPECT().InChan().Return(testChan)
-
-	// Send test input through the channel
-	input := `{"key": "value"}`
-	timestamp := time.Date(2015, 07, 1, 13, 14, 15, 0, time.UTC).UnixNano()
-	go func() {
-		testPack := pipeline.PipelinePack{
-			Message: &message.Message{
-				Payload:   &input,
-				Timestamp: &timestamp,
-			},
-		}
-
-		testChan <- &testPack
-		close(testChan)
-	}()
-
-	expected := `{"created":"2015-07-01 13:14:15.000","key":"value"}`
-	mockFirehose.EXPECT().PutRecord([]byte(expected)).Return(nil)
-
-	err := firehoseOutput.Run(mockOR, mockPH)
-	assert.NoError(t, err, "did not expect err for valid Run()")
-}
-
-// TestRunWithoutData tests that if an empty row is passed to the plugin
-// then the plugin returns an error but continues
-func TestRunWithoutData(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	mockOR := pipelinemock.NewMockOutputRunner(mockCtrl)
-	mockPH := pipelinemock.NewMockPluginHelper(mockCtrl)
-	mockFirehose := NewMockRecordPutter(mockCtrl)
-
 	firehoseOutput := FirehoseOutput{
-		client:          mockFirehose,
-		timestampColumn: "created",
+		client: mockFirehose,
+		conf:   &conf,
+		or:     mockOR,
 	}
-
-	testChan := make(chan *pipeline.PipelinePack)
-	mockOR.EXPECT().InChan().Return(testChan)
 
 	// Send test input through the channel
 	input := `{}`
+	testPack := pipeline.PipelinePack{
+		Message: &message.Message{
+			Payload: &input,
+		},
+		QueueCursor: "queuecursor",
+	}
+
+	err := firehoseOutput.ProcessMessage(&testPack)
+	assert.Error(t, err, "did not return err for empty json object")
+}
+
+// TestMessageWithTimestamp tests that if a TimestampColumn is provided in the config
+// then the Heka message's timestamp gets added to the message with that column name.
+func TestMessageWithTimestamp(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockOR := pipelinemock.NewMockOutputRunner(mockCtrl)
+	mockFirehose := NewMockRecordPutter(mockCtrl)
+	conf := FirehoseOutputConfig{
+		TimestampColumn: "created",
+		FlushCount:      1,
+		FlushInterval:   0,
+	}
+	firehoseOutput := FirehoseOutput{
+		client: mockFirehose,
+		conf:   &conf,
+		or:     mockOR,
+	}
+
+	// Send test input through the channel
+	input := `{"key":"value"}`
 	timestamp := time.Date(2015, 07, 1, 13, 14, 15, 0, time.UTC).UnixNano()
-	go func() {
-		testPack := pipeline.PipelinePack{
-			Message: &message.Message{
-				Payload:   &input,
-				Timestamp: &timestamp,
-			},
-		}
+	testPack := pipeline.PipelinePack{
+		Message: &message.Message{
+			Payload:   &input,
+			Timestamp: &timestamp,
+		},
+		QueueCursor: "queuecursor",
+	}
 
-		testChan <- &testPack
-		close(testChan)
-	}()
+	expected := `{"created":"2015-07-01 13:14:15.000","key":"value"}`
+	mockFirehose.EXPECT().PutRecord([]byte(expected)).Return(nil)
+	mockOR.EXPECT().UpdateCursor("queuecursor")
+	err := firehoseOutput.ProcessMessage(&testPack)
+	assert.NoError(t, err, "did not expect err for valid message")
+}
 
-	expected_error := errors.New("No fields found in message")
-	mockOR.EXPECT().LogError(expected_error).Return()
+// TestMessageBatching makes sure that messages are batched appropriately
+func TestMessageBatching(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
 
-	err := firehoseOutput.Run(mockOR, mockPH)
-	assert.NoError(t, err, "don't fail Run() for no fields found")
+	mockOR := pipelinemock.NewMockOutputRunner(mockCtrl)
+	mockPH := pipelinemock.NewMockPluginHelper(mockCtrl)
+	mockClient := NewMockRecordPutter(mockCtrl)
+	conf := FirehoseOutputConfig{
+		FlushCount:    3,
+		FlushInterval: 1000,
+	}
+
+	firehoseOutput := new(FirehoseOutput)
+	err := firehoseOutput.Init(&conf)
+	assert.NoError(t, err, "did not expect error from Init()")
+	// override the client with a mock
+	firehoseOutput.client = mockClient
+
+	// create a real stop channel
+	mockChan := make(chan bool)
+	mockOR.EXPECT().StopChan().Return(mockChan)
+	err = firehoseOutput.Prepare(mockOR, mockPH)
+	assert.NoError(t, err, "did not expect error from Prepare()")
+
+	// Send 3 messages to trigger the flush
+	input1 := `{"key":"value1"}`
+	testPack1 := pipeline.PipelinePack{
+		Message: &message.Message{
+			Payload: &input1,
+		},
+		QueueCursor: "queuecursor1",
+	}
+
+	input2 := `{"key":"value2"}`
+	testPack2 := pipeline.PipelinePack{
+		Message: &message.Message{
+			Payload: &input2,
+		},
+		QueueCursor: "queuecursor2",
+	}
+
+	input3 := `{"key":"value3"}`
+	testPack3 := pipeline.PipelinePack{
+		Message: &message.Message{
+			Payload: &input3,
+		},
+		QueueCursor: "queuecursor3",
+	}
+
+	expected := [][]byte{
+		[]byte(`{"key":"value1"}`),
+		[]byte(`{"key":"value2"}`),
+		[]byte(`{"key":"value3"}`),
+	}
+
+	err = firehoseOutput.ProcessMessage(&testPack1)
+	assert.NoError(t, err, "did not expect err for valid message (1)")
+	runtime.Gosched()
+
+	err = firehoseOutput.ProcessMessage(&testPack2)
+	assert.NoError(t, err, "did not expect err for valid message (2)")
+	runtime.Gosched()
+
+	mockClient.EXPECT().PutRecordBatch(expected).Return(nil)
+	mockOR.EXPECT().UpdateCursor("queuecursor3")
+	err = firehoseOutput.ProcessMessage(&testPack3)
+	assert.NoError(t, err, "did not expect err for valid message (3)")
+	runtime.Gosched()
+
+	// Make sure everything got sent and cleanup
+	assert.Equal(t, 0, len(firehoseOutput.batchedRecords), "pending records should be empty")
+	assert.Equal(t, 3, firehoseOutput.sentRecordCount, "3 messages should have been sent")
+	assert.Equal(t, 3, firehoseOutput.recvRecordCount, "3 messages should have been recv")
+	assert.Equal(t, 0, firehoseOutput.droppedRecordCount, "0 messages should have been dropped")
+	firehoseOutput.CleanUp()
 }


### PR DESCRIPTION
This PR covers two things:
1) adds batching support which is mostly copied from the elasticsearch output in `heka-private`.
2) Updates the plugin to use the `output` interface instead of the one for inputs

I've tested locally using heka-testing and have added a basic unittest.
