### PR TITLE
InfluxDB Line Protocol: batch filter for heka

### DIFF
--- a/lua/filters/influxdbbatch9.lua
+++ b/lua/filters/influxdbbatch9.lua
@@ -370,16 +370,13 @@ local function points_tags_tables(config)
     -- defined.
     local tags = {}
     local testoutput = ""
-    if not config.carbon_format
-        and (config.tag_fields_all
+    if (config.tag_fields_all
         or config.tag_fields_all_base
         or config.used_tag_fields) then
             for field in pairs(used_fields(base_fields_tag_list, config.skip_fields)) do
                 if config.tag_fields_all or config.tag_fields_all_base or used_tag_fields[field] then
-                    if not skip_fields[field] then
-                        local value = read_message(field)
-                        table.insert(tags, influxdb_kv_fmt(field).."="..tostring(influxdb_kv_fmt(value)))
-                    end
+                    local value = read_message(field)
+                    table.insert(tags, influxdb_kv_fmt(field).."="..tostring(influxdb_kv_fmt(value)))
                 end
             end
     end
@@ -408,7 +405,7 @@ local function points_tags_tables(config)
             -- Include the dynamic fields as tags if they are defined in
             -- configuration or the magic value "**all**" is defined.
             -- Convert value to a string as this is required by the API
-            if not config["carbon_format"] and not skip_fields[field]
+            if not config["carbon_format"]
                 and (config["tag_fields_all"]
                 or (config["used_tag_fields"] and used_tag_fields[field])) then
                     table.insert(tags, influxdb_kv_fmt(field).."="..tostring(influxdb_kv_fmt(value)))

--- a/lua/filters/influxdblinebatch.lua
+++ b/lua/filters/influxdblinebatch.lua
@@ -155,9 +155,9 @@ function encode_scalar_value(value, decimal_precision)
         -- points in time.  Forcing them to always be floats avoids this.
         return string.format("%."..tostring(decimal_precision).."f", value)
     elseif type(value) == "string" then
-        -- first unescape already escaped `"`
-        value_dec = value:gsub('\\"', '"')
-        -- string values need to be double quoted
+        -- first unescape `"` and then escape `\`
+        value_dec = tostring(value):gsub('\\"', '"'):gsub('\\', '\\\\')
+        -- string values need to be double quoted. and escape `"`
         return '"' .. value_dec:gsub('"', '\\"') .. '"'
     elseif type(value) == "boolean" then
         -- don't quote booleans


### PR DESCRIPTION
Ahem. Github now does not show the _move_ since files have diverged enough. 

* remove all excess code not required for InfluxDB line protocol
* simplify configuration
* separate functions for `field` and `tag` encoding


TODO: 
* sort `tags` before writing to string as InfluxDB docs say it gives better performance[1]
* (maybe) can we somehow deal with low resolution timestamps without resorting to internal counters?
 

[1]: [Tags should be sorted by key before being sent for best performance. The sort should match that from the Go bytes.Compare function (http://golang.org/pkg/bytes/#Compare).](https://docs.influxdata.com/influxdb/v0.12/write_protocols/line/)