### PR TITLE
Fix metric name and dimensions in log-monitor

### DIFF
--- a/lua/filters/log_monitor.lua
+++ b/lua/filters/log_monitor.lua
@@ -9,7 +9,8 @@ Config:
 - msg_type (string, optional, defaults to 'log-monitor')
 - metric_name (string, optional, defaults to 'log-monitor')
 - hostname (string, optional, defaults to 'unknown')
-    Set the hostname (or container name) 
+- component (string, optional, defaults to 'unknown')
+- environment (string, optional, defaults to 'unknown')
 
 *Example Heka Configuration*
 
@@ -22,10 +23,9 @@ Config:
     filename = "lua/filters/timestamp.lua"
     ticker_interval = 1
 		[LastSeenTimestamp.config]
-		msg_type = "log-monitor"
-		metric_name = "log-monitor"
-		hostname = "HekaParser"
-
+		hostname = "%ENV[HOSTNAME]"
+		component = "logparser"
+		environment = "production"
 
 --]]
 
@@ -34,14 +34,17 @@ require "string"
 require "table"
 
 local msg_type = read_config("msg_type") or "log-monitor"
-local metric_name = read_config("metric_name") or "log-monitor"
+local metric_name = read_config("metric_name") or "heka.latest-log-timestamp"
 local hostname = read_config("hostname") or "unknown"
+local component = read_config("component") or "unknown"
+local environment = read_config("environment") or "unknown"
 local last_timestamp = 0
 
 function process_message()
     local ts = tonumber(read_message("Timestamp"))
     -- convert from Unix nanoseconds to Unix seconds
     last_timestamp = ts / 1e9
+
     return 0
 end
 
@@ -51,7 +54,11 @@ function timer_event(ns)
     local datapoint = {
     	metric=metric_name,
     	value=last_timestamp,
-    	dimensions={hostname=hostname} 
+    	dimensions={
+            hostname=hostname,
+            environment=environment,
+            component=component,
+        }
     }
     table.insert(gauges, datapoint)
     output.gauge = gauges


### PR DESCRIPTION
Tested in `heka-testing` 

Related PRs:
- heka-testing: https://github.com/Clever/heka-testing/pull/64
- heka-outputs: https://github.com/Clever/heka-outputs/pull/97
- log-router: https://github.com/Clever/log-router/pull/31

**NOTE** This needs to be merged first so that the other repos can pull the latest version of `heka-clever-plugins`
