### PR TITLE
Generalize redshift output

### DIFF
--- a/batcher/message_batcher.go
+++ b/batcher/message_batcher.go
@@ -13,10 +13,10 @@ type Batcher interface {
 	// Interval at which accumulated messages should be bulk put to
 	// firehose (default 1 second).
 	FlushInterval(dur time.Duration)
-	// Number of messages that triggers a put to firehose
+	// Number of messages that triggers a push to firehose
 	// default to 10
 	FlushCount(count int)
-	// Number of messages that triggers a put to firehose
+	// Size of batch that triggers a push to firehose
 	// default to 1mb (1024 * 1024)
 	FlushSize(size int)
 

--- a/batcher/message_batcher.go
+++ b/batcher/message_batcher.go
@@ -1,0 +1,117 @@
+package batcher
+
+import (
+	"time"
+)
+
+type message []byte
+
+type Sync interface {
+	Flush(batch []message)
+}
+
+type Batcher interface {
+	// Interval at which accumulated messages should be bulk put to
+	// firehose (default 1 second).
+	FlushInterval(dur time.Duration)
+	// Number of messages that triggers a put to firehose
+	// default to 10
+	FlushCount(count int)
+	// Number of messages that triggers a put to firehose
+	// default to 1mb (1024 * 1024)
+	FlushSize(size int)
+
+	// Messages for length 0 are ignored
+	SendMessage(msg message)
+	Flush()
+}
+
+type batcher struct {
+	flushInterval time.Duration
+	flushCount    int
+	flushSize     int
+
+	sync      Sync
+	msgChan   chan<- message
+	flushChan chan<- struct{}
+}
+
+func New(sync Sync) *batcher {
+	msgChan := make(chan message)
+	flushChan := make(chan struct{})
+
+	b := &batcher{
+		flushCount:    10,
+		flushInterval: time.Second,
+		flushSize:     1024 * 1024,
+
+		sync:      sync,
+		msgChan:   msgChan,
+		flushChan: flushChan,
+	}
+
+	go b.startBatcher(msgChan, flushChan)
+
+	return b
+}
+
+func (b *batcher) FlushInterval(dur time.Duration) {
+	b.flushInterval = dur
+}
+
+func (b *batcher) FlushCount(count int) {
+	b.flushCount = count
+}
+
+func (b *batcher) FlushSize(size int) {
+	b.flushSize = size
+}
+
+func (b *batcher) SendMessage(msg message) {
+	if len(msg) > 0 {
+		b.msgChan <- msg
+	}
+}
+
+func (b *batcher) Flush() {
+	b.flushChan <- struct{}{}
+}
+
+func (b *batcher) batchSize(batch []message) int {
+	total := 0
+	for _, msg := range batch {
+		total += len(msg)
+	}
+
+	return total
+}
+
+func (b *batcher) sendBatch(batch []message) []message {
+	if len(batch) > 0 {
+		b.sync.Flush(batch)
+	}
+	return []message{}
+}
+
+func (b *batcher) startBatcher(msgChan <-chan message, flushChan <-chan struct{}) {
+	batch := []message{}
+
+	for {
+		select {
+		case <-time.After(b.flushInterval):
+			batch = b.sendBatch(batch)
+		case <-flushChan:
+			batch = b.sendBatch(batch)
+		case msg := <-msgChan:
+			size := b.batchSize(batch)
+			if b.flushSize < size+len(msg) {
+				batch = b.sendBatch(batch)
+			}
+
+			batch = append(batch, msg)
+			if b.flushCount <= len(batch) || b.flushSize <= b.batchSize(batch) {
+				batch = b.sendBatch(batch)
+			}
+		}
+	}
+}

--- a/batcher/message_batcher_test.go
+++ b/batcher/message_batcher_test.go
@@ -10,18 +10,20 @@ import (
 
 type mockSync struct {
 	flushChan chan struct{}
-	batches   [][]message
+	batches   [][]Message
+	metadatas [][]interface{}
 }
 
 func NewMockSync() *mockSync {
 	return &mockSync{
 		flushChan: make(chan struct{}, 1),
-		batches:   [][]message{},
+		batches:   [][]Message{},
 	}
 }
 
-func (m *mockSync) Flush(batch []message) {
+func (m *mockSync) Flush(batch []Message, metadata []interface{}) {
 	m.batches = append(m.batches, batch)
+	m.metadatas = append(m.metadatas, metadata)
 	m.flushChan <- struct{}{}
 }
 
@@ -43,17 +45,21 @@ func TestBatchingByCount(t *testing.T) {
 	batcher.FlushInterval(time.Hour)
 	batcher.FlushCount(2)
 
-	batcher.SendMessage(message("hihi"))
-	batcher.SendMessage(message("heyhey"))
-	batcher.SendMessage(message("hmmhmm")) // Shouldn't be in first batch
+	assert.NoError(batcher.Send(Message("hihi"), "meta-hi"))
+	assert.NoError(batcher.Send(Message("heyhey"), "meta-hey"))
+	assert.NoError(batcher.Send(Message("hmmhmm"), "meta-hmm")) // Shouldn't be in first batch
 
 	err = sync.waitForFlush(time.Millisecond * 10)
 	assert.NoError(err)
 
 	assert.Equal(1, len(sync.batches))
 	assert.Equal(2, len(sync.batches[0]))
+	assert.Equal(len(sync.batches), len(sync.metadatas))
+	assert.Equal(len(sync.batches[0]), len(sync.metadatas[0]))
 	assert.Equal("hihi", string(sync.batches[0][0]))
 	assert.Equal("heyhey", string(sync.batches[0][1]))
+	assert.Equal("meta-hi", sync.metadatas[0][0].(string))
+	assert.Equal("meta-hey", sync.metadatas[0][1].(string))
 
 	err = sync.waitForFlush(time.Millisecond * 10)
 	assert.Error(err)
@@ -68,24 +74,30 @@ func TestBatchingByTime(t *testing.T) {
 	batcher.FlushInterval(time.Millisecond)
 	batcher.FlushCount(2000000)
 
-	batcher.SendMessage(message("hihi"))
+	assert.NoError(batcher.Send(Message("hihi"), "meta-hi"))
 
 	err = sync.waitForFlush(time.Millisecond * 10)
 	assert.NoError(err)
 
 	assert.Equal(1, len(sync.batches))
 	assert.Equal(1, len(sync.batches[0]))
+	assert.Equal(len(sync.batches), len(sync.metadatas))
+	assert.Equal(len(sync.batches[0]), len(sync.metadatas[0]))
 	assert.Equal("hihi", string(sync.batches[0][0]))
+	assert.Equal("meta-hi", sync.metadatas[0][0].(string))
 
-	batcher.SendMessage(message("heyhey"))
-	batcher.SendMessage(message("yoyo"))
+	assert.NoError(batcher.Send(Message("heyhey"), "meta-hey"))
+	assert.NoError(batcher.Send(Message("yoyo"), "meta-yo"))
 
 	err = sync.waitForFlush(time.Millisecond * 10)
 	assert.NoError(err)
 
 	assert.Equal(2, len(sync.batches))
 	assert.Equal(2, len(sync.batches[1]))
+	assert.Equal(len(sync.batches), len(sync.metadatas))
+	assert.Equal(len(sync.batches[1]), len(sync.metadatas[1]))
 	assert.Equal("heyhey", string(sync.batches[1][0]))
+	assert.Equal("meta-hey", sync.metadatas[1][0].(string))
 
 	err = sync.waitForFlush(time.Millisecond * 10)
 	assert.Error(err)
@@ -101,36 +113,48 @@ func TestBatchingBySize(t *testing.T) {
 	batcher.FlushCount(2000000)
 	batcher.FlushSize(8)
 
-	batcher.SendMessage(message("hellohello")) // Large messages are sent immediately
+	// Large messages are sent immediately
+	assert.NoError(batcher.Send(Message("hellohello"), "meta-hello"))
 
 	err = sync.waitForFlush(time.Millisecond * 10)
 	assert.NoError(err)
 
 	assert.Equal(1, len(sync.batches))
 	assert.Equal(1, len(sync.batches[0]))
+	assert.Equal(len(sync.batches), len(sync.metadatas))
+	assert.Equal(len(sync.batches[0]), len(sync.metadatas[0]))
 	assert.Equal("hellohello", string(sync.batches[0][0]))
+	assert.Equal("meta-hello", sync.metadatas[0][0].(string))
 
-	batcher.SendMessage(message("heyhey")) // Batcher tries not to exceed size limit
-	batcher.SendMessage(message("hihi"))
+	// Batcher tries not to exceed size limit
+	assert.NoError(batcher.Send(Message("heyhey"), "meta-hey"))
+	assert.NoError(batcher.Send(Message("hihi"), "meta-hi"))
 
 	err = sync.waitForFlush(time.Millisecond * 10)
 	assert.NoError(err)
 
 	assert.Equal(2, len(sync.batches))
 	assert.Equal(1, len(sync.batches[1]))
+	assert.Equal(len(sync.batches), len(sync.metadatas))
+	assert.Equal(len(sync.batches[1]), len(sync.metadatas[1]))
 	assert.Equal("heyhey", string(sync.batches[1][0]))
+	assert.Equal("meta-hey", sync.metadatas[1][0].(string))
 
-	batcher.SendMessage(message("yoyo")) // At this point "hihi" is in the batch
+	assert.NoError(batcher.Send(Message("yoyo"), "meta-yo")) // At this point "hihi" is in the batch
 
 	err = sync.waitForFlush(time.Millisecond * 10)
 	assert.NoError(err)
 
 	assert.Equal(3, len(sync.batches))
 	assert.Equal(2, len(sync.batches[2]))
+	assert.Equal(len(sync.batches), len(sync.metadatas))
+	assert.Equal(len(sync.batches[2]), len(sync.metadatas[2]))
 	assert.Equal("hihi", string(sync.batches[2][0]))
 	assert.Equal("yoyo", string(sync.batches[2][1]))
+	assert.Equal("meta-hi", sync.metadatas[2][0].(string))
+	assert.Equal("meta-yo", sync.metadatas[2][1].(string))
 
-	batcher.SendMessage(message("okok"))
+	assert.NoError(batcher.Send(Message("okok"), ""))
 
 	err = sync.waitForFlush(time.Millisecond * 10)
 	assert.Error(err)
@@ -145,7 +169,7 @@ func TestFlushing(t *testing.T) {
 	batcher.FlushInterval(time.Hour)
 	batcher.FlushCount(2000000)
 
-	batcher.SendMessage(message("hihi"))
+	assert.NoError(batcher.Send(Message("hihi"), "meta-hi"))
 
 	err = sync.waitForFlush(time.Millisecond * 10)
 	assert.Error(err)
@@ -157,5 +181,19 @@ func TestFlushing(t *testing.T) {
 
 	assert.Equal(1, len(sync.batches))
 	assert.Equal(1, len(sync.batches[0]))
+	assert.Equal(len(sync.batches), len(sync.metadatas))
+	assert.Equal(len(sync.batches[0]), len(sync.metadatas[0]))
 	assert.Equal("hihi", string(sync.batches[0][0]))
+	assert.Equal("meta-hi", sync.metadatas[0][0].(string))
+}
+
+func TestSendingEmpty(t *testing.T) {
+	var err error
+	assert := assert.New(t)
+
+	sync := NewMockSync()
+	batcher := New(sync)
+
+	err = batcher.Send(Message{}, "")
+	assert.Error(err)
 }

--- a/batcher/message_batcher_test.go
+++ b/batcher/message_batcher_test.go
@@ -1,0 +1,161 @@
+package batcher
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockSync struct {
+	flushChan chan struct{}
+	batches   [][]message
+}
+
+func NewMockSync() *mockSync {
+	return &mockSync{
+		flushChan: make(chan struct{}, 1),
+		batches:   [][]message{},
+	}
+}
+
+func (m *mockSync) Flush(batch []message) {
+	m.batches = append(m.batches, batch)
+	m.flushChan <- struct{}{}
+}
+
+func (m *mockSync) waitForFlush(timeout time.Duration) error {
+	select {
+	case <-m.flushChan:
+		return nil
+	case <-time.After(timeout):
+		return fmt.Errorf("The flush never came.  I waited %s.", timeout.String())
+	}
+}
+
+func TestBatchingByCount(t *testing.T) {
+	var err error
+	assert := assert.New(t)
+
+	sync := NewMockSync()
+	batcher := New(sync)
+	batcher.FlushInterval(time.Hour)
+	batcher.FlushCount(2)
+
+	batcher.SendMessage(message("hihi"))
+	batcher.SendMessage(message("heyhey"))
+	batcher.SendMessage(message("hmmhmm")) // Shouldn't be in first batch
+
+	err = sync.waitForFlush(time.Millisecond * 10)
+	assert.NoError(err)
+
+	assert.Equal(1, len(sync.batches))
+	assert.Equal(2, len(sync.batches[0]))
+	assert.Equal("hihi", string(sync.batches[0][0]))
+	assert.Equal("heyhey", string(sync.batches[0][1]))
+
+	err = sync.waitForFlush(time.Millisecond * 10)
+	assert.Error(err)
+}
+
+func TestBatchingByTime(t *testing.T) {
+	var err error
+	assert := assert.New(t)
+
+	sync := NewMockSync()
+	batcher := New(sync)
+	batcher.FlushInterval(time.Millisecond)
+	batcher.FlushCount(2000000)
+
+	batcher.SendMessage(message("hihi"))
+
+	err = sync.waitForFlush(time.Millisecond * 10)
+	assert.NoError(err)
+
+	assert.Equal(1, len(sync.batches))
+	assert.Equal(1, len(sync.batches[0]))
+	assert.Equal("hihi", string(sync.batches[0][0]))
+
+	batcher.SendMessage(message("heyhey"))
+	batcher.SendMessage(message("yoyo"))
+
+	err = sync.waitForFlush(time.Millisecond * 10)
+	assert.NoError(err)
+
+	assert.Equal(2, len(sync.batches))
+	assert.Equal(2, len(sync.batches[1]))
+	assert.Equal("heyhey", string(sync.batches[1][0]))
+
+	err = sync.waitForFlush(time.Millisecond * 10)
+	assert.Error(err)
+}
+
+func TestBatchingBySize(t *testing.T) {
+	var err error
+	assert := assert.New(t)
+
+	sync := NewMockSync()
+	batcher := New(sync)
+	batcher.FlushInterval(time.Hour)
+	batcher.FlushCount(2000000)
+	batcher.FlushSize(8)
+
+	batcher.SendMessage(message("hellohello")) // Large messages are sent immediately
+
+	err = sync.waitForFlush(time.Millisecond * 10)
+	assert.NoError(err)
+
+	assert.Equal(1, len(sync.batches))
+	assert.Equal(1, len(sync.batches[0]))
+	assert.Equal("hellohello", string(sync.batches[0][0]))
+
+	batcher.SendMessage(message("heyhey")) // Batcher tries not to exceed size limit
+	batcher.SendMessage(message("hihi"))
+
+	err = sync.waitForFlush(time.Millisecond * 10)
+	assert.NoError(err)
+
+	assert.Equal(2, len(sync.batches))
+	assert.Equal(1, len(sync.batches[1]))
+	assert.Equal("heyhey", string(sync.batches[1][0]))
+
+	batcher.SendMessage(message("yoyo")) // At this point "hihi" is in the batch
+
+	err = sync.waitForFlush(time.Millisecond * 10)
+	assert.NoError(err)
+
+	assert.Equal(3, len(sync.batches))
+	assert.Equal(2, len(sync.batches[2]))
+	assert.Equal("hihi", string(sync.batches[2][0]))
+	assert.Equal("yoyo", string(sync.batches[2][1]))
+
+	batcher.SendMessage(message("okok"))
+
+	err = sync.waitForFlush(time.Millisecond * 10)
+	assert.Error(err)
+}
+
+func TestFlushing(t *testing.T) {
+	var err error
+	assert := assert.New(t)
+
+	sync := NewMockSync()
+	batcher := New(sync)
+	batcher.FlushInterval(time.Hour)
+	batcher.FlushCount(2000000)
+
+	batcher.SendMessage(message("hihi"))
+
+	err = sync.waitForFlush(time.Millisecond * 10)
+	assert.Error(err)
+
+	batcher.Flush()
+
+	err = sync.waitForFlush(time.Millisecond * 10)
+	assert.NoError(err)
+
+	assert.Equal(1, len(sync.batches))
+	assert.Equal(1, len(sync.batches[0]))
+	assert.Equal("hihi", string(sync.batches[0][0]))
+}

--- a/kv_firehose_output.go
+++ b/kv_firehose_output.go
@@ -1,0 +1,225 @@
+package heka_clever_plugins
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/Clever/heka-clever-plugins/aws"
+	"github.com/Clever/heka-clever-plugins/batcher"
+
+	"github.com/mozilla-services/heka/message"
+	"github.com/mozilla-services/heka/pipeline"
+)
+
+type KVFirehoseOutput struct {
+	conf     *KVFirehoseOutputConfig
+	or       pipeline.OutputRunner
+	batchers map[string]batcher.Batcher
+
+	mockEndpoint string
+
+	reportLock         sync.Mutex
+	recvRecordCount    int64
+	sentRecordCount    int64
+	droppedRecordCount int64
+}
+
+type KVFirehoseOutputConfig struct {
+	// The value of this field is used as the firehose `series` (or stream) name
+	SeriesField string `toml:"series_field"`
+	// Optional. The value of this config is used as the field name to put the timestamp in
+	TimestampColumnField string `toml:"timestamp_column_field"`
+
+	// AWS region the stream lives in
+	Region string `toml:"region"`
+	// Interval at which accumulated messages should be bulk put to
+	// firehose, in milliseconds (default 1000, i.e. 1 second).
+	FlushInterval uint32 `toml:"flush_interval"`
+	// Number of messages that triggers a put to firehose
+	// (default to 1, maximum is 500)
+	FlushCount int `toml:"flush_count"`
+	// Number of messages that triggers a put to firehose
+	// (default to 1024 * 1024 (1mb))
+	FlushSize int `toml:"flush_size"`
+}
+
+type syncPutterAdapter struct {
+	client aws.RecordPutter
+	output *KVFirehoseOutput
+}
+
+func (s *syncPutterAdapter) Flush(batch [][]byte, metadatas []interface{}) {
+	count := int64(len(batch))
+
+	// TODO add retry logic
+	err := s.client.PutRecordBatch(batch)
+
+	// Update the cursor (these messages are either lost forever or sent)
+	// and reset the queue
+	s.output.or.UpdateCursor(metadatas[len(metadatas)-1].(string))
+
+	if err != nil {
+		// TODO: PutRecordBatch should return the number of successful records
+		//       so that the correct amount can be set here
+		atomic.AddInt64(&s.output.droppedRecordCount, count)
+		s.output.or.LogError(err)
+	} else {
+		atomic.AddInt64(&s.output.sentRecordCount, count)
+	}
+}
+
+func (f *KVFirehoseOutput) ConfigStruct() interface{} {
+	return &KVFirehoseOutputConfig{
+		FlushInterval: 1000,
+		FlushCount:    1,
+		FlushSize:     1024 * 1024,
+	}
+}
+
+func (f *KVFirehoseOutput) Init(config interface{}) error {
+	f.conf = config.(*KVFirehoseOutputConfig)
+
+	if f.conf.FlushCount > 500 {
+		return fmt.Errorf("FlushCount cannot exceed 500 messages")
+	}
+
+	f.batchers = map[string]batcher.Batcher{}
+
+	if os.Getenv("HEKA_TESTING") != "" {
+		endpoint := os.Getenv("MOCK_FIREHOSE_ENDPOINT")
+		if endpoint == "" {
+			return fmt.Errorf("env-var MOCK_FIREHOSE_ENDPOINT not found for heka-testing")
+		}
+		fmt.Println("Mocking out firehose output: " + endpoint)
+		f.mockEndpoint = endpoint
+	}
+
+	return nil
+}
+
+func (f *KVFirehoseOutput) Prepare(or pipeline.OutputRunner, h pipeline.PluginHelper) error {
+	f.or = or
+
+	go f.listenForStop(or.StopChan())
+
+	return nil
+}
+
+func (f *KVFirehoseOutput) listenForStop(stopChan <-chan bool) {
+	<-stopChan
+
+	for _, batch := range f.batchers {
+		batch.Flush()
+	}
+}
+
+func (f *KVFirehoseOutput) createBatcherSync(seriesName string) batcher.Sync {
+	var client aws.RecordPutter
+
+	if f.mockEndpoint == "" {
+		client = aws.NewFirehose(f.conf.Region, seriesName)
+	} else {
+		fmt.Printf("Mocking out firehose output '%s' to %s\n", seriesName, f.mockEndpoint)
+		client = aws.NewMockRecordPutter(seriesName, f.mockEndpoint)
+	}
+
+	return &syncPutterAdapter{client: client, output: f}
+}
+
+func (f *KVFirehoseOutput) parseFields(pack *pipeline.PipelinePack) (
+	seriesName string, timestampColumn string, object map[string]interface{},
+) {
+	m := pack.Message
+	object = make(map[string]interface{})
+
+	// Handle standard heka fields
+	object["uuid"] = m.GetUuidString()
+	object["timestamp"] = time.Unix(0, m.GetTimestamp()).Format("2006-01-02 15:04:05.000")
+	object["type"] = m.GetType()
+	object["logger"] = m.GetLogger()
+	object["severity"] = m.GetSeverity()
+	object["payload"] = m.GetPayload()
+	object["envversion"] = m.GetEnvVersion()
+	object["pid"] = m.GetPid()
+	object["hostname"] = m.GetHostname()
+
+	seriesName = ""
+	timestampColumn = ""
+	// store each dynamic field as a top level entry
+	for _, field := range m.Fields {
+		fieldType := field.GetValueType()
+
+		if *field.Name == f.conf.SeriesField && fieldType == message.Field_STRING {
+			seriesName = field.GetValue().(string)
+		} else if *field.Name == f.conf.TimestampColumnField && fieldType == message.Field_STRING {
+			timestampColumn = field.GetValue().(string)
+		} else if field.Name != nil && fieldType != message.Field_BYTES {
+			// ignore byte fields and empty fields
+			object[*field.Name] = field.GetValue()
+		}
+	}
+	return seriesName, timestampColumn, object
+}
+
+func (f *KVFirehoseOutput) ProcessMessage(pack *pipeline.PipelinePack) error {
+	atomic.AddInt64(&f.recvRecordCount, 1)
+	timestamp := time.Unix(0, pack.Message.GetTimestamp()).Format("2006-01-02 15:04:05.000")
+	seriesName, timestampColumn, object := f.parseFields(pack)
+
+	if seriesName == "" {
+		atomic.AddInt64(&f.droppedRecordCount, 1)
+		return errors.New("No series name found in message")
+	}
+
+	if len(object) == 0 {
+		atomic.AddInt64(&f.droppedRecordCount, 1)
+		return errors.New("No fields found in message")
+	}
+
+	if timestampColumn != "" {
+		object[timestampColumn] = timestamp
+	}
+
+	record, err := json.Marshal(object)
+	if err != nil {
+		atomic.AddInt64(&f.droppedRecordCount, 1)
+		return err
+	}
+
+	batch, ok := f.batchers[seriesName]
+	if !ok {
+		sync := f.createBatcherSync(seriesName)
+		batch = batcher.New(sync)
+		f.batchers[seriesName] = batch
+	}
+	batch.Send(record, pack.QueueCursor)
+
+	return nil
+}
+
+func (f *KVFirehoseOutput) CleanUp() {
+}
+
+func (f *KVFirehoseOutput) ReportMsg(msg *message.Message) error {
+	f.reportLock.Lock()
+	defer f.reportLock.Unlock()
+
+	message.NewInt64Field(msg, "sentRecordCount",
+		atomic.LoadInt64(&f.sentRecordCount), "count")
+	message.NewInt64Field(msg, "droppedRecordCount",
+		atomic.LoadInt64(&f.droppedRecordCount), "count")
+	message.NewInt64Field(msg, "recvRecordCount",
+		atomic.LoadInt64(&f.recvRecordCount), "count")
+	return nil
+}
+
+func init() {
+	pipeline.RegisterPlugin("KVFirehoseOutput", func() interface{} {
+		return new(KVFirehoseOutput)
+	})
+}

--- a/kv_firehose_output.go
+++ b/kv_firehose_output.go
@@ -53,8 +53,20 @@ type syncPutterAdapter struct {
 func (s *syncPutterAdapter) Flush(batch [][]byte, metadatas []interface{}) {
 	count := int64(len(batch))
 
-	// TODO add retry logic
-	err := s.client.PutRecordBatch(batch)
+	var err error
+	// Expotential backoff with retry limit
+	for retries, delay := 0, 1; retries < 5; retries, delay = retries+1, delay*2 {
+		err = s.client.PutRecordBatch(batch)
+
+		if err == nil {
+			break
+		}
+
+		s.output.or.LogError(
+			fmt.Errorf("Firehose put-record failure: %s.  Retry %d", err.Error(), retries))
+
+		time.Sleep(time.Duration(delay*250) * time.Millisecond)
+	}
 
 	// Update the cursor (these messages are either lost forever or sent)
 	// and reset the queue

--- a/kv_firehose_output.go
+++ b/kv_firehose_output.go
@@ -37,10 +37,10 @@ type KVFirehoseOutputConfig struct {
 	// Interval at which accumulated messages should be bulk put to
 	// firehose, in milliseconds (default 1000, i.e. 1 second).
 	FlushInterval uint32 `toml:"flush_interval"`
-	// Number of messages that triggers a put to firehose
+	// Number of messages that triggers a push to firehose
 	// (default to 1, maximum is 500)
 	FlushCount int `toml:"flush_count"`
-	// Number of messages that triggers a put to firehose
+	// Size of batch that triggers a push to firehose
 	// (default to 1024 * 1024 (1mb))
 	FlushSize int `toml:"flush_size"`
 }


### PR DESCRIPTION
**Explanation**:

The goal was to eliminate the redundant configuration in the log-router and redshift heka-output.  Ultimately this was achieved by using a `fieldfix` filter in the log-router to embed the name of redshift stream into the message.  Example of the config:

```toml
[SyncEventsDistrictAppCountsFirehoseFilter]
type = "SandboxFilter"
filename = "/heka/clever/filters/fieldfix.lua"
preserve_data = false
message_matcher = "Type == 'Kayvee' && Fields[source] == 'space' && Fields[title] == 'events_from_sync'"
    [SyncEventsDistrictAppCountsFirehoseFilter.config]
    fields_if_missing = "_kvmeta.redshift.series=%ENV[FIREHOSE_EVENTS_DISTRICT_APP_COUNTS]"
```

As a result the number of outputs in the log-router and redshift heka-outputs was greatly reduced.  

Only a single AMQP output for redshift was needed in the log-router:
```toml
[RedshiftAMQPOutput]
type = "AMQPOutput"
url = "amqp://%ENV[HEKA_OUTPUT_QUEUE_USER]:%ENV[HEKA_OUTPUT_QUEUE_PASS]@%ENV[HEKA_OUTPUT_QUEUE_HOST]/"
exchange = "outputs"
exchange_type = "direct"
exchange_durability = true
persistent = true
routing_key = "redshift"
message_matcher = "Fields[_kvmeta.redshift.series] != NIL"
```

Only one firehose output is needed in the redshift heka-output:
```toml
[KVRedshiftOutput]
type = "KVFirehoseOutput"
region = "us-west-2"
series_field = "_kvmeta.redshift.series"
message_matcher = "Fields[_kvmeta.redshift.series] != NIL"
flush_count = 500
flush_interval = 10000 # 10 seconds
flush_size=5242880 # 5mb
```

This PR further simplifies redshift output by removing the `timestamp_column` config option.  By default timestamps are added to the `time` and `timestamp` columns.  The value is repeated to maintain reverse compatibility.

**Deployment Steps**:
- [ ] Scale log-router to 0
- [ ] Wait for Redshift queue to drain fully
- [ ] Deploy new version of redshift heka-output
- [ ] Deploy new version of log-router
- [ ] Scale log-router back to 8

**Related**:
- https://clever.atlassian.net/browse/INFRA-1953
- https://github.com/Clever/ark-config/pull/37
- https://github.com/Clever/log-router/pull/42
- https://github.com/Clever/heka-outputs/pull/107

TODO:
- [ ] Update heka-clever-plugins sha in heka-private: https://github.com/Clever/heka-private/blob/clever/cmake/plugin_loader.cmake#L11

cc @burnsed 