### PR TITLE
kvmeta decoder now sets default 'logs' route

### DIFF
--- a/lua/decoders/kvmeta.lua
+++ b/lua/decoders/kvmeta.lua
@@ -88,7 +88,6 @@ function process_message()
     -- Inject one message for each valid route
     for _, route in ipairs(routes) do
         local msg_copy = deepcopy(msg)
-        msg_copy.Fields["_kvmeta"] = nil
         local valid_route = true
         for k, v in pairs(route) do
             -- 'dimensions' must be an array of strings

--- a/lua/decoders/kvmeta.lua
+++ b/lua/decoders/kvmeta.lua
@@ -2,11 +2,20 @@
 
 Splits a message into multiple messages, with attached routing information.
 
+Config:
+
+- type (string, optional):
+    Sets the message 'Type' field. If unset, has no effect on the message's 'Type'.
+
 --]=]
 
 local cjson = require "cjson"
 local field_util = require "field_util"
 local table = require "table"
+
+local config = {
+    msg_type = read_config("type")
+}
 
 local base_fields = field_util.field_map()
 base_fields['Timestamp'] = true
@@ -64,9 +73,12 @@ function process_message()
     MAX_ROUTES = 10
     if #routes > MAX_ROUTES then return -1 end
 
-    -- Copy message completely, removing routing info
+    -- Copy the message, so we can modify inject various routed versions of it.
+    --  * `_kvmeta` routing info
+    --  * set msg.Type, if it was specified in the Decoder's config
     local msg = copy_message()
     msg.Fields["_kvmeta"] = nil
+    if config.msg_type then msg.Type = config.msg_type end
 
     -- Inject original message, with type 'logs'
     local msg_copy = deepcopy(msg)

--- a/lua/decoders/kvmeta.lua
+++ b/lua/decoders/kvmeta.lua
@@ -64,16 +64,19 @@ function process_message()
     MAX_ROUTES = 10
     if #routes > MAX_ROUTES then return -1 end
 
-    -- Copy message completely, then remove routing info
+    -- Copy message completely, removing routing info
     local msg = copy_message()
     msg.Fields["_kvmeta"] = nil
 
-    -- Inject original message, with routing removed
-    inject_message(msg)
+    -- Inject original message, with type 'logs'
+    local msg_copy = deepcopy(msg)
+    msg_copy.Fields["_kvmeta.type"] = 'logs'
+    inject_message(msg_copy)
 
     -- Inject one message for each valid route
     for _, route in ipairs(routes) do
         local msg_copy = deepcopy(msg)
+        msg_copy.Fields["_kvmeta"] = nil
         local valid_route = true
         for k, v in pairs(route) do
             -- 'dimensions' must be an array of strings

--- a/lua/decoders/kvmeta.lua
+++ b/lua/decoders/kvmeta.lua
@@ -4,7 +4,7 @@ Splits a message into multiple messages, with attached routing information.
 
 Config:
 
-- type (string, optional):
+- msg_type (string, optional):
     Sets the message 'Type' field. If unset, has no effect on the message's 'Type'.
 
 --]=]
@@ -14,7 +14,7 @@ local field_util = require "field_util"
 local table = require "table"
 
 local config = {
-    msg_type = read_config("type")
+    msg_type = read_config("msg_type")
 }
 
 local base_fields = field_util.field_map()

--- a/lua/decoders/kvmeta_spec.lua
+++ b/lua/decoders/kvmeta_spec.lua
@@ -62,6 +62,7 @@ describe("KV Decoder", function()
 
         expected_msg1 = util.deepcopy(msg)
         expected_msg1.Fields._kvmeta = nil
+        expected_msg1.Fields["_kvmeta.type"] = "logs"
         assert.same(expected_msg1, injected[1])
     end)
 
@@ -75,6 +76,7 @@ describe("KV Decoder", function()
 
         expected_msg1 = util.deepcopy(mock_msg)
         expected_msg1.Fields._kvmeta = nil
+        expected_msg1.Fields["_kvmeta.type"] = "logs"
         assert.same(expected_msg1, injected[1])
 
         expected_msg2 = util.deepcopy(mock_msg)

--- a/lua/decoders/kvmeta_spec.lua
+++ b/lua/decoders/kvmeta_spec.lua
@@ -101,7 +101,7 @@ describe("KV Decoder", function()
         -- Test setup
         mocks.reset()
         local cfg =  util.deepcopy(mock_cfg)
-        cfg['type'] = 'kvmeta' -- we expect this to be set on the injected message
+        cfg['msg_type'] = 'kvmeta' -- we expect this to be set on the injected message
         mocks.set_config(cfg)
         util.unrequire('kvmeta')
         require 'kvmeta'

--- a/lua/util.lua
+++ b/lua/util.lua
@@ -64,4 +64,12 @@ function module.lines(str)
   return t
 end
 
+-- Unload a module.
+-- We need this so we can require a Heka lua plugin multiple times, with different config.
+-- http://lua-users.org/lists/lua-l/2009-03/msg00587.html
+function module.unrequire(m)
+    package.loaded[m] = nil
+    _G[m] = nil
+end
+
 return module


### PR DESCRIPTION
Previously, it injected one message without any kvmeta.

Now, it's more explicit if it matches a message, and anything that's
routedb by kvmeta decoder will always have a `_kvmeta.type` field set.