### PR TITLE
Added nil check to avoid panic

### DIFF
--- a/aws/firehose.go
+++ b/aws/firehose.go
@@ -82,7 +82,7 @@ func (f Firehose) PutRecordBatch(records [][]byte) error {
 
 		retryRecords := [][]byte{}
 		for idx, entry := range res.RequestResponses {
-			if *entry.ErrorMessage != "" {
+			if entry != nil && *entry.ErrorMessage != "" {
 				kvlog.ErrorD("failed-record", logger.M{
 					"stream": f.stream, "msg": &entry.ErrorMessage,
 				})


### PR DESCRIPTION
Noticed a panic in prod: http://search-logs-v23-7qghqi2w3g6ywh4dhyoh32awia.us-west-2.es.amazonaws.com/_plugin/kibana/#/discover?_g=(refreshInterval:(display:Off,pause:!f,section:0,value:0),time:(from:'2016-10-17T00:00:00.000Z',mode:absolute,to:'2016-10-17T00:30:00.000Z'))&_a=(columns:!(rawlog),filters:!(),index:%5Blogs-%5DYYYY.MM.DD,interval:auto,query:(query_string:(analyze_wildcard:!t,lowercase_expanded_terms:!f,query:'container_app:heka-outputs-redshift')),sort:!(Timestamp,desc))

This should fix it.