### PR TITLE
INFRA-2065 Fix a panic in the firehose output

### DIFF
--- a/aws/firehose.go
+++ b/aws/firehose.go
@@ -82,7 +82,7 @@ func (f Firehose) PutRecordBatch(records [][]byte) error {
 
 		retryRecords := [][]byte{}
 		for idx, entry := range res.RequestResponses {
-			if entry != nil && *entry.ErrorMessage != "" {
+			if entry != nil && entry.ErrorMessage != nil && *entry.ErrorMessage != "" {
 				kvlog.ErrorD("failed-record", logger.M{
 					"stream": f.stream, "msg": &entry.ErrorMessage,
 				})


### PR DESCRIPTION
There is a dereference in the firehouse output that sometimes causes panics.  I have tracked the panic down to this specific line.  Because the same `PutRecordBatchResponseEntry` is used for success and failure, sometimes `entry.Message` is nil.

You can see that this panic correlates very clearly to all of our crashes/imbalances by querying in kibana for `failed-record OR panic OR "firehose.go\:85"`