### PR TITLE
allow overriding container_{app,env,task}

### DIFF
--- a/lua/decoders/clever_container_decoder.lua
+++ b/lua/decoders/clever_container_decoder.lua
@@ -9,6 +9,10 @@ require "string"
 function process_message()
     local programname = read_message("Fields[programname]")
 
+    local force_env = read_message("Fields[container_env]")
+    local force_app = read_message("Fields[container_app]")
+    local force_task = read_message("Fields[container_task]")
+
     if programname == nil or programname == "" then return -1 end
 
     pat =
@@ -17,6 +21,17 @@ function process_message()
         "(%x%x%x%x%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%x%x%x%x%x%x%x%x)$" -- task-id
 
     _, _, env, app, task = string.find(programname, pat)
+
+    -- override env, app, task if forced
+    if force_env and force_env ~= "" then
+      env = force_env
+    end
+    if force_app and force_app ~= "" then
+      app = force_app
+    end
+    if force_task and force_task ~= "" then
+      task = force_task
+    end
 
     if env and app and task then
         write_message("Fields[logtag]", ("%s--%s/%s"):format(env, app, task))

--- a/lua/decoders/clever_container_decoder_spec.lua
+++ b/lua/decoders/clever_container_decoder_spec.lua
@@ -119,4 +119,26 @@ describe("Clever Container fields", function()
         assert.equals("apiservice", written_messages["Fields[container_app]"])
         assert.equals("abcd", written_messages["Fields[container_task]"])
     end)
+    it("Does not override container values with empty values", function()
+        mocks.reset()
+        require 'clever_container_decoder'
+
+        local mock_msg= {}
+        mock_msg['Timestamp'] = 2000000
+        mock_msg['Hostname'] = "hostname"
+        mock_msg.Fields = {}
+        mock_msg.Fields.programname = "docker/production--some-api/arn%3Aaws%3Aecs%3Aus-west-1%3A589690932525%3Atask%2F12345678-1234-1234-1234-1234567890ab"
+        mock_msg.Fields.container_env = ""
+        mock_msg.Fields.container_app = ""
+        mock_msg.Fields.container_task = ""
+        mocks.set_next_message(mock_msg)
+
+        assert.equals(process_message(), 0, "Should process_message successfully")
+        written_messages = mocks.written_messages()
+
+        assert.equals("production--some-api/12345678-1234-1234-1234-1234567890ab", written_messages["Fields[logtag]"])
+        assert.equals("production", written_messages["Fields[container_env]"])
+        assert.equals("some-api", written_messages["Fields[container_app]"])
+        assert.equals("12345678-1234-1234-1234-1234567890ab", written_messages["Fields[container_task]"])
+    end)
 end)

--- a/lua/decoders/clever_container_decoder_spec.lua
+++ b/lua/decoders/clever_container_decoder_spec.lua
@@ -1,0 +1,122 @@
+-- Allow importing from parent directory
+package.path = package.path .. ";../?.lua"
+
+local mocks = require 'mocks'
+local util = require 'util'
+
+describe("Clever Container fields", function()
+    it("Log lines must have programname", function()
+        mocks.reset()
+        require 'clever_container_decoder'
+
+        local mock_msg= {}
+        mock_msg['Timestamp'] = 2000000
+        mock_msg['Hostname'] = "hostname"
+        mock_msg.Fields = {}
+        mocks.set_next_message(mock_msg)
+
+        assert.equals(process_message(), -1, "process_message should fail")
+        written_messages = mocks.written_messages()
+    end)
+    it("Container fields are created from programname", function()
+        mocks.reset()
+        require 'clever_container_decoder'
+
+        local mock_msg= {}
+        mock_msg['Timestamp'] = 2000000
+        mock_msg['Hostname'] = "hostname"
+        mock_msg.Fields = {}
+        mock_msg.Fields.programname = "docker/production--some-api/arn%3Aaws%3Aecs%3Aus-west-1%3A589690932525%3Atask%2F12345678-1234-1234-1234-1234567890ab"
+        mocks.set_next_message(mock_msg)
+
+        assert.equals(process_message(), 0, "Should process_message successfully")
+        written_messages = mocks.written_messages()
+
+        assert.equals("production--some-api/12345678-1234-1234-1234-1234567890ab", written_messages["Fields[logtag]"])
+        assert.equals("production", written_messages["Fields[container_env]"])
+        assert.equals("some-api", written_messages["Fields[container_app]"])
+        assert.equals("12345678-1234-1234-1234-1234567890ab", written_messages["Fields[container_task]"])
+    end)
+    it("Container field container_env can be overriden", function()
+        mocks.reset()
+        require 'clever_container_decoder'
+
+        local mock_msg= {}
+        mock_msg['Timestamp'] = 2000000
+        mock_msg['Hostname'] = "hostname"
+        mock_msg.Fields = {}
+        mock_msg.Fields.programname = "docker/production--some-api/arn%3Aaws%3Aecs%3Aus-west-1%3A589690932525%3Atask%2F12345678-1234-1234-1234-1234567890ab"
+        mock_msg.Fields.container_env = "development"
+        mocks.set_next_message(mock_msg)
+
+        assert.equals(process_message(), 0, "Should process_message successfully")
+        written_messages = mocks.written_messages()
+
+        assert.equals("development--some-api/12345678-1234-1234-1234-1234567890ab", written_messages["Fields[logtag]"])
+        assert.equals("development", written_messages["Fields[container_env]"])
+        assert.equals("some-api", written_messages["Fields[container_app]"])
+        assert.equals("12345678-1234-1234-1234-1234567890ab", written_messages["Fields[container_task]"])
+    end)
+    it("Container field container_app can be overriden", function()
+        mocks.reset()
+        require 'clever_container_decoder'
+
+        local mock_msg= {}
+        mock_msg['Timestamp'] = 2000000
+        mock_msg['Hostname'] = "hostname"
+        mock_msg.Fields = {}
+        mock_msg.Fields.programname = "docker/production--some-api/arn%3Aaws%3Aecs%3Aus-west-1%3A589690932525%3Atask%2F12345678-1234-1234-1234-1234567890ab"
+        mock_msg.Fields.container_app = "apiservice"
+        mocks.set_next_message(mock_msg)
+
+        assert.equals(process_message(), 0, "Should process_message successfully")
+        written_messages = mocks.written_messages()
+
+        assert.equals("production--apiservice/12345678-1234-1234-1234-1234567890ab", written_messages["Fields[logtag]"])
+        assert.equals("production", written_messages["Fields[container_env]"])
+        assert.equals("apiservice", written_messages["Fields[container_app]"])
+        assert.equals("12345678-1234-1234-1234-1234567890ab", written_messages["Fields[container_task]"])
+    end)
+    it("Container field container_task can be overriden", function()
+        mocks.reset()
+        require 'clever_container_decoder'
+
+        local mock_msg= {}
+        mock_msg['Timestamp'] = 2000000
+        mock_msg['Hostname'] = "hostname"
+        mock_msg.Fields = {}
+        mock_msg.Fields.programname = "docker/production--some-api/arn%3Aaws%3Aecs%3Aus-west-1%3A589690932525%3Atask%2F12345678-1234-1234-1234-1234567890ab"
+        mock_msg.Fields.container_task = "abcd"
+        mocks.set_next_message(mock_msg)
+
+        assert.equals(process_message(), 0, "Should process_message successfully")
+        written_messages = mocks.written_messages()
+
+        assert.equals("production--some-api/abcd", written_messages["Fields[logtag]"])
+        assert.equals("production", written_messages["Fields[container_env]"])
+        assert.equals("some-api", written_messages["Fields[container_app]"])
+        assert.equals("abcd", written_messages["Fields[container_task]"])
+    end)
+    it("All Container fields can be overriden", function()
+        mocks.reset()
+        require 'clever_container_decoder'
+
+        local mock_msg= {}
+        mock_msg['Timestamp'] = 2000000
+        mock_msg['Hostname'] = "hostname"
+        mock_msg.Fields = {}
+        mock_msg.Fields.programname = "docker/production--some-api/arn%3Aaws%3Aecs%3Aus-west-1%3A589690932525%3Atask%2F12345678-1234-1234-1234-1234567890ab"
+        mock_msg.Fields.container_env = "development"
+        mock_msg.Fields.container_app = "apiservice"
+        mock_msg.Fields.container_task = "abcd"
+        mocks.set_next_message(mock_msg)
+
+        assert.equals(process_message(), 0, "Should process_message successfully")
+        written_messages = mocks.written_messages()
+
+        assert.equals("development--apiservice/abcd", written_messages["Fields[logtag]"])
+        assert.equals("development", written_messages["Fields[container_env]"])
+        assert.equals("apiservice", written_messages["Fields[container_app]"])
+        assert.equals("abcd", written_messages["Fields[container_task]"])
+    end)
+end)


### PR DESCRIPTION
- [x] needs testing

This PR allows logs to manually inject their own container_{app,env,task}.