### PR TITLE
Kvmeta read from routes key

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,10 @@ $(ROCKSDIR)/busted:
 
 lua-tests: lua-deps # Run tests for lua-based plugins
 	@echo "Running tests for ./lua/filters"
-	@pushd ./lua/filters; busted .; popd
+	@pushd ./lua/filters; busted . && popd
 	@echo ""
 	@echo "Running tests for ./lua/decoders"
-	@pushd ./lua/decoders; busted .; popd
+	@pushd ./lua/decoders; busted . && popd
 	@echo ""
 	@echo "Running tests for ./lua/encoders"
-	@pushd ./lua/encoders; busted .; popd
+	@pushd ./lua/encoders; busted . && popd

--- a/lua/decoders/kvmeta.lua
+++ b/lua/decoders/kvmeta.lua
@@ -64,12 +64,14 @@ end
 
 function process_message()
     -- Error if _kvmeta isn't set
-    local kvmeta = read_message("Fields[_kvmeta]")
-    if not kvmeta then return -1 end
+    local kvmeta_field = read_message("Fields[_kvmeta]")
+    if not kvmeta_field then return -1 end
 
-    -- Read routes off of message
-    local ok, routes = pcall(cjson.decode, kvmeta)
-    if not ok or not routes then return -1 end
+    local ok, kvmeta = pcall(cjson.decode, kvmeta_field)
+    if not ok or not kvmeta then return -1 end
+
+    local routes = kvmeta["routes"]
+    if not routes then return -1 end
     MAX_ROUTES = 10
     if #routes > MAX_ROUTES then return -1 end
 

--- a/lua/decoders/kvmeta.lua
+++ b/lua/decoders/kvmeta.lua
@@ -80,6 +80,15 @@ function process_message()
     --  * set msg.Type, if it was specified in the Decoder's config
     local msg = copy_message()
     msg.Fields["_kvmeta"] = nil
+    for k, v in pairs(kvmeta) do
+        -- Append metadata for everything except "routes".
+        -- We handle each route below.
+        -- This adds things like `kv_version` or `kv_language`.
+        if k ~= "routes" then
+            msg.Fields["_kvmeta."..k] = v
+        end
+    end
+
     if config.msg_type then msg.Type = config.msg_type end
 
     -- Inject original message, with type 'logs'

--- a/lua/decoders/kvmeta_spec.lua
+++ b/lua/decoders/kvmeta_spec.lua
@@ -19,19 +19,21 @@ describe("KV Decoder", function()
     mock_msg.Fields.custom_dim1 = "custom_value"
     mock_msg.Fields.custom_dim2 = "custom_value"
     mock_msg.Fields._kvmeta = cjson.encode({
-        {
-            rule="rule-1-alerts",
-            type="alerts",
-            series="series_1",
-            value="value_a",
-            dimensions={},
-        },
-        {
-            rule="rule-2-metrics",
-            type="metrics",
-            series="series_b",
-            dimensions={"custom_dim1", "custom_dim2"},
-        },
+        routes = {
+            {
+                rule="rule-1-alerts",
+                type="alerts",
+                series="series_1",
+                value="value_a",
+                dimensions={},
+            },
+            {
+                rule="rule-2-metrics",
+                type="metrics",
+                series="series_b",
+                dimensions={"custom_dim1", "custom_dim2"},
+            },
+        }
     })
 
     function test_setup()
@@ -53,7 +55,7 @@ describe("KV Decoder", function()
     it("should inject original message and remove _kvmeta field", function()
         test_setup()
         local msg = util.deepcopy(mock_msg)
-        msg.Fields._kvmeta = cjson.encode({})
+        msg.Fields._kvmeta = cjson.encode({routes={}})
         mocks.set_next_message(msg)
 
         assert.equals(0, process_message(), "process_message should succeed")
@@ -107,7 +109,7 @@ describe("KV Decoder", function()
         require 'kvmeta'
 
         local msg = util.deepcopy(mock_msg)
-        msg.Fields._kvmeta = cjson.encode({})
+        msg.Fields._kvmeta = cjson.encode({routes={}})
         mocks.set_next_message(msg)
 
         -- Test


### PR DESCRIPTION
Previously, looked for routes array under `_kvmeta` top level key.

Now looks for `routes` inside kvmeta dict:

```json
{
    "_kvmeta": {
        "routes": [ ]
    }
}
```

This is a fix due to a minor bug in how the spec was implemented.

cc @xavi- 

-- 

also includes a `Makefile` fix: https://github.com/Clever/heka-clever-plugins/pull/82/commits/2f6a52a34f9d3108247231a4ecd6ebbca135372d .. `lua-tests` wasn't returning an error properly because of using `;` vs `&&`