### PR TITLE
Set default values for influx and signalfx

### DIFF
--- a/lua/filters/kayvee_influxdblinebatch.lua
+++ b/lua/filters/kayvee_influxdblinebatch.lua
@@ -214,7 +214,7 @@ local function tags_fields_tables(config)
 
     -- Get value
     local value = read_field(read_field(config.value_ref_field))
-    if not value then value = 1 end
+    if not value then value = 0 end
     fields = { value = value }
 
     -- TAGS

--- a/lua/filters/kayvee_influxdblinebatch.lua
+++ b/lua/filters/kayvee_influxdblinebatch.lua
@@ -214,7 +214,7 @@ local function tags_fields_tables(config)
 
     -- Get value
     local value = read_field(read_field(config.value_ref_field))
-    if not value then return nil end
+    if not value then value = 1 end
     fields = { value = value }
 
     -- TAGS

--- a/lua/filters/kayvee_influxdblinebatch_spec.lua
+++ b/lua/filters/kayvee_influxdblinebatch_spec.lua
@@ -114,6 +114,22 @@ describe("Kayvee Influxdbline Batch Filter", function()
         assert.equals("series-name,env=test,Hostname=hostname value=999.000000 2\n", actual_msg.data)
     end)
 
+    it("should default to 1 if value isn't found", function()
+        -- Test setup
+        test_setup()
+        mock_msg_new = util.deepcopy(mock_msg)
+        mock_msg_new.Fields.value = nil
+        mocks.set_next_message(mock_msg_new)
+
+        -- Test
+        assert.equals(process_message(), 0, "Should process_message successfully")
+        flush()
+        injected = mocks.injected_payloads()
+        assert.equals(#injected, 1)
+        actual_msg = injected[1]
+        assert.equals("series-name,env=test,Hostname=hostname value=1.000000 2\n", actual_msg.data)
+    end)
+
     it("should read dimensions from specified field", function()
         -- Test setup
         test_setup()

--- a/lua/filters/kayvee_influxdblinebatch_spec.lua
+++ b/lua/filters/kayvee_influxdblinebatch_spec.lua
@@ -114,7 +114,7 @@ describe("Kayvee Influxdbline Batch Filter", function()
         assert.equals("series-name,env=test,Hostname=hostname value=999.000000 2\n", actual_msg.data)
     end)
 
-    it("should default to 1 if value isn't found", function()
+    it("should default to 0 if value isn't found", function()
         -- Test setup
         test_setup()
         mock_msg_new = util.deepcopy(mock_msg)
@@ -127,7 +127,7 @@ describe("Kayvee Influxdbline Batch Filter", function()
         injected = mocks.injected_payloads()
         assert.equals(#injected, 1)
         actual_msg = injected[1]
-        assert.equals("series-name,env=test,Hostname=hostname value=1.000000 2\n", actual_msg.data)
+        assert.equals("series-name,env=test,Hostname=hostname value=0.000000 2\n", actual_msg.data)
     end)
 
     it("should read dimensions from specified field", function()

--- a/lua/filters/kayvee_signalfxbatch.lua
+++ b/lua/filters/kayvee_signalfxbatch.lua
@@ -172,7 +172,6 @@ function process_message()
 
     -- Get value
     local value = read_field(read_field(config.value_ref_field))
-    if not value then return -1 end
 
     -- Get stat_type
     local stat_type = read_field(config.stat_type_field)


### PR DESCRIPTION
In the two real-world examples of people using the alerts output, neither used a proper `value` quantity, so it makes sense to add default values.

cc @nathanleiby 