### PR TITLE
add newlines to firehose output

### DIFF
--- a/firehose_output.go
+++ b/firehose_output.go
@@ -152,6 +152,9 @@ func (f *FirehoseOutput) ProcessMessage(pack *pipeline.PipelinePack) error {
 		atomic.AddInt64(&f.droppedRecordCount, 1)
 		return err
 	}
+	// records ending in newlines will ensure the json objects written to
+	// firehose appear one per line
+	record = append(record, '\n')
 
 	// Send data to the batcher
 	f.batchChan <- MsgPack{record: record, queueCursor: pack.QueueCursor}


### PR DESCRIPTION
Right now the data we write to Firehose consists of consecutive JSON objects with no newlines separating them. This is inconvenient for analyzing the data when forwarded to S3 as the raw text.

At first I thought this might have an impact on Firehose outputs that forward to Redshift, but it appears as though the Redshift COPY operation does not require JSON objects to be newline separated: http://docs.aws.amazon.com/redshift/latest/dg/copy-parameters-data-format.html#copy-json

